### PR TITLE
Add method to bridge calls from native to web

### DIFF
--- a/PopupBridge/Classes/POPPopUpBridge.h
+++ b/PopupBridge/Classes/POPPopUpBridge.h
@@ -38,6 +38,28 @@ extern NSString * const kPOPURLHost;
 /// @param delegate A delegate that presents and dismisses the Safari View Controllers.
 - (id)initWithWebView:(WKWebView *)webView delegate:(id<POPPopupBridgeDelegate>)delegate;
 
+/// @brief Send a message with optional data to the JavaScript context in the web view.
+///
+/// The web page can receive this message by setting `window.popupBridge.bridgeToWeb` to a custom function:
+///
+/// @code
+/// // JavaScript
+/// window.popupBridge.bridgeToWeb = function (messageName, data) {
+///   console.log('My native app sent me message ' + messageName + ' with data: ' + data);
+/// };
+///
+/// // iOS
+/// [popupBridge bridgeToWeb:@"messageName" data:"This is my data" completionHandler:nil];
+/// // In the webview console: "My native app sent me message messageName with data: This is my data"
+/// @endcode
+///
+/// @param messageName The name of the message
+/// @param data An optional string payload to send with the message. This can be used to send JSON strings that are parsed and deserialized by the web page.
+/// @param completionHandler An optional completion handler that executes when the message has been sent. It returns the return value or an error.
+- (void)bridgeToWeb:(NSString *)messageName
+               data:(nullable NSString *)data
+  completionHandler:(void (^ _Nullable)(id _Nullable returnValue, NSError * _Nullable error))completionHandler;
+
 /// Set the URL Scheme that you have registered in your Info.plist.
 + (void)setReturnURLScheme:(NSString *)returnURLScheme;
 


### PR DESCRIPTION
## Summary

Currently, PopupBridge exposes `sendMessage` for JS -> Native communication, but there isn't a generic interface for going Native -> JS. This PR adds this capability with `bridgeToWeb:data:completionHandler:`.

Calling `bridgeToWeb:data:completionHandler:` will invoke `window.popupBridge.bridgeToWeb(messageName, data);`. It is the responsibility of the JS layer to set `window.popupBridge.bridgeToWeb` to a function.

## Other things

I renamed the JS `sendMessage` function to keep the semantics clearer. It has been renamed to `bridgeToNative`.

I've also removed the function wrapper from the JavaScript template -- it was not necessary.