### PR TITLE
Add destroy() function which releases ScriptMessageHandler

### DIFF
--- a/PopupBridge/Classes/POPPopUpBridge.h
+++ b/PopupBridge/Classes/POPPopUpBridge.h
@@ -38,6 +38,9 @@ extern NSString * const kPOPURLHost;
 /// @param delegate A delegate that presents and dismisses the Safari View Controllers.
 - (id)initWithWebView:(WKWebView *)webView delegate:(id<POPPopupBridgeDelegate>)delegate;
 
+// Call destroy before discarding the webView, otherwise the WebView instance will not be destroyed
+-(void)destroy;
+
 /// Set the URL Scheme that you have registered in your Info.plist.
 + (void)setReturnURLScheme:(NSString *)returnURLScheme;
 
@@ -52,5 +55,5 @@ extern NSString * const kPOPURLHost;
 + (BOOL)openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options;
 
 @end
-
 NS_ASSUME_NONNULL_END
+


### PR DESCRIPTION
Should be called before dismissing the WebView instance, otherwise the WebView instance continues to exist after dismissal, taking up memory (can still be seen as present in Safari Web Inspector).
See https://stackoverflow.com/a/32443518/777265