### PR TITLE
Add POPWeakScriptMessageDelegate to prevent reference cycle

### DIFF
--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3055485E0BA8E1A26E7B80CB /* Pods_PopupBridge_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 872803D34D74C00ACDF1EC3C /* Pods_PopupBridge_Tests.framework */; };
+		419433E41F6753A400E83483 /* POPWeakScriptMessageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 419433E31F6753A400E83483 /* POPWeakScriptMessageDelegate.h */; };
+		419433E51F6753FD00E83483 /* POPWeakScriptMessageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 419433E11F67534E00E83483 /* POPWeakScriptMessageDelegate.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -70,6 +72,8 @@
 
 /* Begin PBXFileReference section */
 		317783C3F96DAB0943150A60 /* Pods-PopupBridge_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PopupBridge_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		419433E11F67534E00E83483 /* POPWeakScriptMessageDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = POPWeakScriptMessageDelegate.m; path = Classes/POPWeakScriptMessageDelegate.m; sourceTree = "<group>"; };
+		419433E31F6753A400E83483 /* POPWeakScriptMessageDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POPWeakScriptMessageDelegate.h; sourceTree = "<group>"; };
 		4D9C5526F903288B5284342D /* Pods-PopupBridge_Example-PopupBridge_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PopupBridge_Example-PopupBridge_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PopupBridge_Example-PopupBridge_Tests/Pods-PopupBridge_Example-PopupBridge_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* PopupBridge_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PopupBridge_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -265,6 +269,8 @@
 				A73D5A051DFA2E1500387737 /* POPPopupBridge.m */,
 				A79330F01DF0F98F00EE479D /* PopupBridge-Framework-Info.plist */,
 				A775A08D1DEE4EF0009E67C2 /* PopupBridge.h */,
+				419433E11F67534E00E83483 /* POPWeakScriptMessageDelegate.m */,
+				419433E31F6753A400E83483 /* POPWeakScriptMessageDelegate.h */,
 			);
 			path = PopupBridge;
 			sourceTree = "<group>";
@@ -278,6 +284,7 @@
 			files = (
 				A775A08F1DEE4EF0009E67C2 /* PopupBridge.h in Headers */,
 				A73D5A061DFA2E1500387737 /* POPPopupBridge.h in Headers */,
+				419433E41F6753A400E83483 /* POPWeakScriptMessageDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +528,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A73D5A071DFA2E1500387737 /* POPPopupBridge.m in Sources */,
+				419433E51F6753FD00E83483 /* POPWeakScriptMessageDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PopupBridge/Classes/POPPopUpBridge.m
+++ b/PopupBridge/Classes/POPPopUpBridge.m
@@ -1,4 +1,5 @@
-#import "POPPopUpBridge.h"
+#import "POPPopupBridge.h"
+#import "POPWeakScriptMessageDelegate.h"
 #import <SafariServices/SFSafariViewController.h>
 
 @interface POPPopupBridge () <SFSafariViewControllerDelegate>
@@ -27,7 +28,9 @@ NSString * const kPOPURLHost = @"popupbridgev1";
         self.delegate = delegate;
         self.webView = webView;
 
-        [webView.configuration.userContentController addScriptMessageHandler:self name:kPOPScriptMessageHandlerName];
+        // Use POPWeakScriptMessageDelegate to prevent a reference cycle where userContentController
+        // maintains a reference to this instance.
+        [webView.configuration.userContentController addScriptMessageHandler:[[POPWeakScriptMessageDelegate alloc] initWithDelegate:self] name:kPOPScriptMessageHandlerName];
 
         NSString *javascript = [[[[self javascriptTemplate] stringByReplacingOccurrencesOfString:@"%%SCHEME%%" withString:scheme]  stringByReplacingOccurrencesOfString:@"%%SCRIPT_MESSAGE_HANDLER_NAME%%" withString:kPOPScriptMessageHandlerName] stringByReplacingOccurrencesOfString:@"%%HOST%%" withString:kPOPURLHost];
         WKUserScript *script = [[WKUserScript alloc] initWithSource:javascript injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];

--- a/PopupBridge/Classes/POPWeakScriptMessageDelegate.m
+++ b/PopupBridge/Classes/POPWeakScriptMessageDelegate.m
@@ -1,0 +1,18 @@
+@import WebKit;
+#import "POPWeakScriptMessageDelegate.h"
+
+@implementation POPWeakScriptMessageDelegate
+
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate {
+    self = [super init];
+    if (self) {
+        _scriptDelegate = scriptDelegate;
+    }
+    return self;
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
+    [self.scriptDelegate userContentController:userContentController didReceiveScriptMessage:message];
+}
+
+@end

--- a/PopupBridge/POPWeakScriptMessageDelegate.h
+++ b/PopupBridge/POPWeakScriptMessageDelegate.h
@@ -1,0 +1,14 @@
+///
+/// From https://stackoverflow.com/a/33365424/766491
+/// This wrapper class provides a weak reference to a WKScriptMessageHandler to prevent
+/// reference cycles caused by WKUserContentController, which retains message handlers
+/// by default.
+///
+
+@interface POPWeakScriptMessageDelegate : NSObject<WKScriptMessageHandler>
+
+@property (nonatomic, weak) id<WKScriptMessageHandler> scriptDelegate;
+
+- (instancetype)initWithDelegate:(id<WKScriptMessageHandler>)scriptDelegate;
+
+@end


### PR DESCRIPTION
An alternative to https://github.com/braintree/popup-bridge-ios/pull/6 to prevent the reference cycle caused by `userContentController` retaining a reference to its message handling delegate (in our case, the `POPPopupBridge` instance).

This solution does not require any code changes from clients to fix the issue.

For more context, see [here](https://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak/33365424#33365424).