### PR TITLE
Add support for URL fragment parsing

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - OCMock
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - OCMock
+
 SPEC CHECKSUMS:
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
 PODFILE CHECKSUM: 34af50f990d52eeea12aa558c68d511fe85e2232
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -337,7 +337,6 @@
 				A775A0791DEE4E7E009E67C2 /* Frameworks */,
 				A775A07A1DEE4E7E009E67C2 /* Resources */,
 				D4096ACC7F2DB0696CEF479D /* [CP] Embed Pods Frameworks */,
-				137FD5E05624646989C7A489 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -449,21 +448,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		137FD5E05624646989C7A489 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		CEC1F8AB75D9DBEDFA9FEBDF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/PopupBridge.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PopupBridge.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/PopupBridge/Classes/POPPopupBridge.m
+++ b/PopupBridge/Classes/POPPopupBridge.m
@@ -133,7 +133,8 @@ NSString * const kPOPURLHost = @"popupbridgev1";
 
                     NSMutableDictionary *payloadDictionary = [NSMutableDictionary new];
                     payloadDictionary[@"path"] = path;
-                    payloadDictionary[@"queryItems"] = [self.class dictionaryForQueryString:url.query];
+                    payloadDictionary[@"queryItems"] = [self.class dictionaryForKeyValueString:url.query];
+                    payloadDictionary[@"hashItems"] = [self.class dictionaryForKeyValueString:url.fragment];
 
                     NSError *error;
                     NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadDictionary options:0 error:&error];
@@ -177,9 +178,9 @@ NSString * const kPOPURLHost = @"popupbridgev1";
 
 #pragma mark - Helpers
 
-+ (NSDictionary *)dictionaryForQueryString:(NSString *)queryString {
++ (NSDictionary *)dictionaryForKeyValueString:(NSString *)keyValueString {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    NSArray *components = [queryString componentsSeparatedByString:@"&"];
+    NSArray *components = [keyValueString componentsSeparatedByString:@"&"];
     for (NSString *keyValueString in components) {
         if ([keyValueString length] == 0) {
             continue;

--- a/PopupBridge/Classes/POPPopupBridge.m
+++ b/PopupBridge/Classes/POPPopupBridge.m
@@ -133,8 +133,10 @@ NSString * const kPOPURLHost = @"popupbridgev1";
 
                     NSMutableDictionary *payloadDictionary = [NSMutableDictionary new];
                     payloadDictionary[@"path"] = path;
-                    payloadDictionary[@"queryItems"] = [self.class dictionaryForKeyValueString:url.query];
-                    payloadDictionary[@"hashItems"] = [self.class dictionaryForKeyValueString:url.fragment];
+                    payloadDictionary[@"queryItems"] = [self.class dictionaryForQueryString:url.query];
+                    if (url.fragment) {
+                        payloadDictionary[@"hash"] = url.fragment;
+                    }
 
                     NSError *error;
                     NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadDictionary options:0 error:&error];
@@ -178,9 +180,9 @@ NSString * const kPOPURLHost = @"popupbridgev1";
 
 #pragma mark - Helpers
 
-+ (NSDictionary *)dictionaryForKeyValueString:(NSString *)keyValueString {
++ (NSDictionary *)dictionaryForQueryString:(NSString *)queryString {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    NSArray *components = [keyValueString componentsSeparatedByString:@"&"];
+    NSArray *components = [queryString componentsSeparatedByString:@"&"];
     for (NSString *keyValueString in components) {
         if ([keyValueString length] == 0) {
             continue;

--- a/PopupBridge_Tests/PopupBridge_Tests.m
+++ b/PopupBridge_Tests/PopupBridge_Tests.m
@@ -198,7 +198,7 @@ static void (^webviewReadyBlock)();
     }] completionHandler:OCMOCK_ANY]);
 }
 
-- (void)testOpenURL_whenReturnURLHasURLFragment_passesPayloadWithHashItemsToWebView {
+- (void)testOpenURL_whenReturnURLHasURLFragment_passesPayloadWithHashToWebView {
     WKScriptMessage *message = OCMClassMock([WKScriptMessage class]);
     OCMStub(message.body).andReturn(@{@"url": @"http://example.com/?hello=world"});
     OCMStub(message.name).andReturn(kPOPScriptMessageHandlerName);
@@ -212,15 +212,13 @@ static void (^webviewReadyBlock)();
         NSString *payload = [[javascriptCommand stringByReplacingOccurrencesOfString:@"window.popupBridge.onComplete(null, " withString:@""] stringByReplacingOccurrencesOfString:@");" withString:@""];
         NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:[payload dataUsingEncoding:NSUTF8StringEncoding] options:0 error:NULL];
         XCTAssertEqualObjects(jsonDictionary[@"path"], @"/return");
-        NSDictionary *hashItems = jsonDictionary[@"hashItems"];
-        NSLog(@"%@", hashItems);
-        XCTAssertEqualObjects(hashItems[@"something"], @"foo");
-        XCTAssertEqualObjects(hashItems[@"other"], @"bar");
+        NSString *hash = jsonDictionary[@"hash"];
+        XCTAssertEqualObjects(hash, @"something=foo&other=bar");
         return YES;
     }] completionHandler:OCMOCK_ANY]);
 }
 
-- (void)testOpenURL_whenReturnURLHasNoURLFragment_passesPayloadWithEmptyHashItemsToWebView {
+- (void)testOpenURL_whenReturnURLHasNoURLFragment_passesPayloadWithNilHashToWebView {
     WKScriptMessage *message = OCMClassMock([WKScriptMessage class]);
     OCMStub(message.body).andReturn(@{@"url": @"http://example.com/?hello=world"});
     OCMStub(message.name).andReturn(kPOPScriptMessageHandlerName);
@@ -234,9 +232,8 @@ static void (^webviewReadyBlock)();
         NSString *payload = [[javascriptCommand stringByReplacingOccurrencesOfString:@"window.popupBridge.onComplete(null, " withString:@""] stringByReplacingOccurrencesOfString:@");" withString:@""];
         NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:[payload dataUsingEncoding:NSUTF8StringEncoding] options:0 error:NULL];
         XCTAssertEqualObjects(jsonDictionary[@"path"], @"/return");
-        NSDictionary *hashItems = jsonDictionary[@"hashItems"];
-        XCTAssertNotNil(hashItems);
-        XCTAssertEqual(hashItems.count, 0);
+        NSString *hash = jsonDictionary[@"hash"];
+        XCTAssertNil(hash);
         return YES;
     }] completionHandler:OCMOCK_ANY]);
 }


### PR DESCRIPTION
## What it does

Currently we only pass the URL path and query string, e.g. `https://popupbridgev1/hi?foo=bar#baz=qux` will return the following JS object:

```
{
  "path": "/there",
  "queryItems": { "foo": "bar" }
}
```

This PR adds support for returning the URL fragment in the PopupBridge payload as `hash`, e.g. with the previous example URL, it'd return:

```
{
  "path": "/there",
  "queryItems": { "foo": "bar" }
  "hash": "baz=qux"
}
```

## Why

This allows PopupBridge to support cases where meaningful data is passed back in the URL fragment.