### PR TITLE
Add isIosWebview property to popupBridge

### DIFF
--- a/Example/POPViewController.m
+++ b/Example/POPViewController.m
@@ -31,4 +31,8 @@
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
+- (void)popupBridge:(POPPopupBridge *)bridge receivedMessage:(NSString *)messageName data:(NSString *)data {
+    NSLog(@"Received message %@ with data %@", messageName, data);
+}
+
 @end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - OCMock
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - OCMock
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 34af50f990d52eeea12aa558c68d511fe85e2232
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.8.4

--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -481,7 +481,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PopupBridge_Tests/Pods-PopupBridge_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/PopupBridge/Classes/POPPopupBridge.m
+++ b/PopupBridge/Classes/POPPopupBridge.m
@@ -90,7 +90,7 @@ NSString * const kPOPURLHost = @"popupbridgev1";
     // NB: This string does not maintain newlines, so you cannot use single-line JS comments.
     return @"\
         ;(function () {\
-            if (!window.popupBridge) { window.popupBridge = {}; };\
+            if (!window.popupBridge) { window.popupBridge = {isIosWebview: true}; };\
             \
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {\
                 return '%%SCHEME%%://%%HOST%%/';\


### PR DESCRIPTION
By having the iOS PopupBridge library set up the `popupBridge` JS object with this property, it makes it trivial for the web app's JS to detect when the web page has been loaded in an iOS webview.