### PR TITLE
Bump to Xcode 14 for all CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,55 +1,26 @@
 name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
-  # Xcode 12 Jobs
   cocoapods:
-    name: CocoaPods (Xcode 12.5)
-    runs-on: macOS-11
+    name: CocoaPods (Xcode 14)
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+      - name: Use Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   spm:
-    name: SPM (Xcode 12.5)
-    runs-on: macOS-11
+    name: SPM (Xcode 14)
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
-
-  # Xcode 13-beta Jobs
-  cocoapods_xcode_beta:
-    name: CocoaPods (Xcode 13-beta)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
-      - name: Install CocoaPod dependencies
-        run: pod install
-      - name: Run pod lib lint
-        run: pod lib lint
-  spm_xcode_beta:
-    name: SPM (Xcode 13-beta)
-    runs-on: macOS-11
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,41 +1,26 @@
 name: Tests
 on: [pull_request, workflow_dispatch]
 jobs:
-  # Xcode 12 Jobs
   unit_test_job:
-    name: Unit (Xcode 12.5)
-    runs-on: macOS-11
+    name: Unit (Xcode 14)
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+      - name: Use Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 12,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
-    name: UI (Xcode 12.5)
-    runs-on: macOS-11
+    name: UI (Xcode 14)
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
-      - name: Install CocoaPod dependencies
-        run: pod install
-      - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 12,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
-
-  # Xcode 13-beta Jobs
-  ui_test_job_xcode_beta:
-    name: UI (Xcode 13-beta)
-    runs-on: macOS-11
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.0.app
+      - name: Use Xcode 14.2
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests


### PR DESCRIPTION
### Summary of changes

- Bump all CI builds to use the latest Xcode version
 - [Apple is requiring Xcode 14.1+](https://developer.apple.com/news/?id=z1erkhzr) for all app releases come April 2023

### Note
- This repo has no automated release script, yet

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo 
