### PR TITLE
Update README & add Migration guide

### DIFF
--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -140,8 +140,8 @@
 		A775A08C1DEE4EF0009E67C2 /* PopupBridge */ = {
 			isa = PBXGroup;
 			children = (
-				8079D7172996B45A00A2E336 /* POPPopupBridgeDelegate.swift */,
 				800A09D72995F143003ED16E /* POPPopupBridge.swift */,
+				8079D7172996B45A00A2E336 /* POPPopupBridgeDelegate.swift */,
 				8079D7192996F6C200A2E336 /* PopupBridgeUserScript.swift */,
 				8079D71B299706F200A2E336 /* URL+QueryDictionary.swift */,
 				A79330F01DF0F98F00EE479D /* PopupBridge-Framework-Info.plist */,

--- a/README.md
+++ b/README.md
@@ -231,49 +231,6 @@ WebView-based checkout flows can accept PayPal with PopupBridge and the [Braintr
         1. Implement methods in your native app depending on whether you are doing one-time payments or vaulted payments. See the [iOS code snippets for PayPal + PopupBridge](popupbridge-paypaldatacollector-ios.md)
 1. Profit!
 
-Using PopupBridge to pass messages to a WebView
------------------------------------------------
-
-Although PopupBridge's primary purpose is to handle popups, it can be used in a more general use case to send URLs from the app to the JavaScript context in the WebView. These URLs can contain arbitrary data.
-
-1. Register a URL type for your app, as described in the Quick Start.
-1. In your application delegate, set up PopupBridge with the URL scheme:
-
-    ```objectivec
-    #import <PopupBridge/PopupBridge-Swift.h>
-
-    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-    {
-        [POPPopupBridge setReturnURLScheme:@"com.my-app.popupbridge"];
-        return YES;
-    }
-    ```
-
-1. Add a handler to the `onComplete` callback:
-
-   ```javascript
-    if (window.popupBridge) {
-      popupBridge.onComplete = function (err, payload) {
-        if (err) {
-          console.error('PopupBridge onComplete Error:', err);
-          return;
-        }
-
-        console.log("Payload path:", payload.path);
-        console.log("Payload query items:", payload.queryItems);
-        console.log("Payload fragment:", payload.hash);
-      };
-    }
-   ```
-
-1. Create a URL that begins with your app's URL scheme and has a path of `popupbridgev1`, e.g. `com.my-app.popupbridge://popupbridgev1`. Add any additional data in the form of URL paths, query items, and fragments.
-1. Call the PopupBridge `openUrl:options:` method with that URL. The `onComplete` handler will receive the URL as the payload. For example, if the URL is `com.my-app.popupbridge://popupbridgev1/hi/there?foo=bar#baz=qux`:
-   ```javascript
-   console.log("Payload path:", payload.path); // "/hi/there"
-   console.log("Payload query items:", payload.queryItems); // {foo: "bar"}
-   console.log("Payload fragment:", payload.hash); // "baz=qux"
-   ```
-
 ## Author
 
 Braintree, code@getbraintree.com

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Quick Start
 1. Register a URL type for your app:
     - In Xcode, click on your project in the Project Navigator and navigate to **App Target** > **Info** > **URL Types**
     - Click **[+]** to add a new URL type
-    - Under **URL Schemes**, enter a unique URL scheme, e.g. `com.my-app.popupbridge`
+    - Under **URL Schemes**, enter a unique URL scheme, e.g. `com.your-company.your-app`
 
     This scheme must start with your app's Bundle ID and be dedicated to PopupBridge app switch returns. For example, if the app bundle ID is `com.your-company.your-app`, then your URL scheme could be `com.your-company.your-app.popupbridge`.
     
@@ -56,7 +56,7 @@ Quick Start
     ```swift
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         URLContexts.forEach { context in
-            if context.url.scheme?.localizedCaseInsensitiveCompare("com.my-app.popupbridge") == .orderedSame {
+            if context.url.scheme?.localizedCaseInsensitiveCompare("com.your-company.your-app.popupbridge") == .orderedSame {
                 POPPopupBridge.open(url: context.url)
             }
         }
@@ -67,7 +67,7 @@ Quick Start
 
     ```swift
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if url.scheme?.localizedCaseInsensitiveCompare("com.my-app.popupbridge") == .orderedSame {
+        if url.scheme?.localizedCaseInsensitiveCompare("com.your-company.your-app.popupbridge") == .orderedSame {
             return POPPopupBridge.open(url: url)
         }
         return false
@@ -89,7 +89,7 @@ Quick Start
             
             self.popupBridge = POPPopupBridge(
                 webView: self.webView,
-                urlScheme: "com.braintreepayments.popupbridge-swift.payments",
+                urlScheme: "com.your-company.your-app.popupbridge",
                 delegate: self
             )
             

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Quick Start
 
     This scheme must start with your app's Bundle ID and be dedicated to PopupBridge app switch returns. For example, if the app bundle ID is `com.your-company.your-app`, then your URL scheme could be `com.your-company.your-app.popupbridge`.
     
-1. Inspect the return URL and then call `PopupBridge:openURL` from either your app delegate or your scene delegate.
+1. Inspect the return URL and then call `PopupBridge.open(url:)` from either your app delegate or your scene delegate.
 
-    If you're using `UISceneDelegate` (introduced in iOS 13), call `POPPopupBridge.open(url:)` from within the `scene:openURLContexts` scene delegate method.
+    If you're using `UISceneDelegate` (introduced in iOS 13), call `POPPopupBridge.open(url:)` from within the `scene(_:openURLContexts:)` scene delegate method.
 
     ```swift
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -63,7 +63,7 @@ Quick Start
     }
     ```
 
-    If you aren't using `UISceneDelegate`, call `PopupBridge:openURL` from within the  `application:openURL:` delegate method of your app delegate.
+    If you aren't using `UISceneDelegate`, call `PopupBridge.open(url:)` from within the  `application(_:open:options:)` delegate method of your app delegate.
 
     ```swift
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {

--- a/README.md
+++ b/README.md
@@ -85,17 +85,17 @@ Quick Start
         override func viewDidLoad() {
             super.viewDidLoad()
 
-            self.view.addSubview(webView)
+            view.addSubview(webView)
             
-            self.popupBridge = POPPopupBridge(
-                webView: self.webView,
+            popupBridge = POPPopupBridge(
+                webView: webView,
                 urlScheme: "com.your-company.your-app.popupbridge",
                 delegate: self
             )
             
             // Replace http://localhost:3099/ with the webpage you want to open in the webview
             let url = URL(string: "http://localhost:3099/")!
-            self.webView.load(URLRequest(url: url))
+            webView.load(URLRequest(url: url))
         }
     }
 
@@ -106,7 +106,7 @@ Quick Start
         }
         
         func popupBridge(_ bridge: PopupBridge.POPPopupBridge, requestsPresentationOfViewController viewController: UIViewController) {
-            self.present(viewController, animated: true)
+            present(viewController, animated: true)
         }
     }
     ```

--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -1,0 +1,22 @@
+# PopupBridge iOS v2 Migration Guide
+
+See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your client integration from v1 to v2.
+
+## Supported Versions
+
+v2 supports a minimum deployment target of iOS 14+. It requires Xcode 14.1+ and Swift 5.7+. If your application contains Objective-C code, the `Enable Modules` build setting must be set to `YES`.
+
+## Code Changes
+
+The `POPPopupBridge.set(returnURLScheme:)` static method was removed. You no longer need to call this in your app delegate. 
+
+Instead, `urlScheme` is now a required parameter to initialize a `POPPopupBridge` instance.
+
+For example:
+```swift
+let popupBridge = POPPopupBridge(
+    webView: webView,
+    urlScheme: "com.your-company.your-app.popupbridge",
+    delegate: self
+)
+```


### PR DESCRIPTION
### Summary of changes

 - Rewrite ObjC snippets in Swift
 - Remove `setReturnURLScheme` step instructions (#46)
 - Remove section "Using PopupBridge to pass messages to a WebView"
    - This is a use-case beyond popups that was for generic use, but does not apply to BT or PP integrations
    - Android doesn't offer this either
 - Use consistent urlScheme string across docs
- Add v2 migration guide
- Alphabetize source files

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo 
