### PR TITLE
Fix various memory leaks caused by capturing self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Convert PopupBridge to Swift
+* Fix memory leaks in POPPopupBridge
 * Breaking Changes
   * Require iOS 14+, Xcode 14.3+, and Swift 5.8+
   * Remove deprecated `POPPopupBridge.open(url:sourceApplication:)` & `POPPopupBridge.open(url:options:)` methods

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -29,12 +29,12 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
 
         configureWebView()
                 
-        returnBlock = { url in
-            guard let script = self.constructJavaScriptCompletionResult(returnURL: url) else {
+        returnBlock = { [weak self] url in
+            guard let script = self?.constructJavaScriptCompletionResult(returnURL: url) else {
                 return
             }
 
-            self.injectWebView(webView: webView, withJavaScript: script)
+            self?.injectWebView(webView: webView, withJavaScript: script)
             return
         }
     }

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -83,7 +83,10 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// Injects custom JavaScript into the merchant's webpage.
     /// - Parameter scheme: the url scheme provided by the merchant
     private func configureWebView() {
-        webView.configuration.userContentController.add(self, name: messageHandlerName)
+        webView.configuration.userContentController.add(
+            WebViewScriptHandler(proxy: self),
+            name: messageHandlerName
+        )
         
         let javascript = PopupBridgeUserScript(
             scheme: PopupBridgeConstants.callbackURLScheme,

--- a/Sources/PopupBridge/WebViewScriptHandler.swift
+++ b/Sources/PopupBridge/WebViewScriptHandler.swift
@@ -1,0 +1,20 @@
+import UIKit
+import WebKit
+
+class WebViewScriptHandler: NSObject {
+    
+    weak var proxy: WKScriptMessageHandler?
+    
+    init(proxy: WKScriptMessageHandler) {
+        self.proxy = proxy
+    }
+    
+}
+
+extension WebViewScriptHandler: WKScriptMessageHandler {
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        proxy?.userContentController(userContentController, didReceive: message)
+    }
+    
+}


### PR DESCRIPTION
### Summary of changes

 - There are various points in POPPopupBridge.swift where self is captured and retained. This causes POPPopupBridge and web views to leak. This change addresses those issues by passing in self as weak reference. Additionally we prevent leaks from using WKScriptMessageHandler by creating a proxy object that weekly retains the handler.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> Joon Hong