### PR TITLE
Add Blank Privacy Manifest to PopupBridge

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
     targets: [
         .target(
             name: "PopupBridge",
-            exclude: ["PopupBridge-Framework-Info.plist"]
+            path: "Sources/PopupBridge", 
+            exclude: ["PopupBridge-Framework-Info.plist"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
     ]
 )

--- a/PopupBridge.podspec
+++ b/PopupBridge.podspec
@@ -22,4 +22,5 @@ Use cases for PopupBridge:
   s.swift_version    = "5.8"
   
   s.source_files = 'Sources/PopupBridge/**/*.swift'
+  s.resource_bundle = { "PopupBridge_PrivacyInfo" => "Sources/PopupBridge/PrivacyInfo.xcprivacy" }
 end

--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		62D5EC522B9F753100D09C5D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62D5EC512B9F753100D09C5D /* PrivacyInfo.xcprivacy */; };
 		79DB9F7F53319F206CDE119E /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28245E4F1AC5126D54985D88 /* Pods_UnitTests.framework */; };
 		800A09D82995F143003ED16E /* POPPopupBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A09D72995F143003ED16E /* POPPopupBridge.swift */; };
 		800E789D29E0958A00D1B0FC /* WebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E789C29E0958A00D1B0FC /* WebViewMessage.swift */; };
@@ -30,6 +31,7 @@
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		6003F591195388D20070C39A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		62D5EC512B9F753100D09C5D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		800A09D72995F143003ED16E /* POPPopupBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POPPopupBridge.swift; sourceTree = "<group>"; };
 		800E789C29E0958A00D1B0FC /* WebViewMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMessage.swift; sourceTree = "<group>"; };
 		800E789E29E09A2A00D1B0FC /* URLDetailsPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDetailsPayload.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				BE8E37B52A17B79E00181FDA /* WebAuthenticationSession.swift */,
 				800E789C29E0958A00D1B0FC /* WebViewMessage.swift */,
 				BEF9ED222A2A6A2C005D54AB /* PopupBridgeConstants.swift */,
+				62D5EC512B9F753100D09C5D /* PrivacyInfo.xcprivacy */,
 			);
 			path = PopupBridge;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62D5EC522B9F753100D09C5D /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/PopupBridge/PrivacyInfo.xcprivacy
+++ b/Sources/PopupBridge/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   PrivacyInfo.xcprivacy
+   PopupBridge
+
+   Created by Alekhya Geddam on 3/11/24.
+   Copyright (c) 2024 Braintree. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Sources/PopupBridge/PrivacyInfo.xcprivacy
+++ b/Sources/PopupBridge/PrivacyInfo.xcprivacy
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   PrivacyInfo.xcprivacy
-   PopupBridge
-
-   Created by Alekhya Geddam on 3/11/24.
-   Copyright (c) 2024 Braintree. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
### Summary of changes

 - Adds a blank `PrivacyInfo.xcprivacy` file to `popup-bridge-ios`
 - References the file in `Package.swift` and `PopupBridge.podspec`.
 - Here's the generated [privacy report](https://github.com/braintree/popup-bridge-ios/files/14591851/Demo-PrivacyReport.2024-03-13.13-06-34.pdf)

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @agedd 
