### PR TITLE
Fix bug launching PopupBridge from iFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PopupBridge iOS Release Notes
 
+## unreleased
+* Inject popup bridge JS script code into all frames, versus just mainframe. Fixes bug where popup bridge couldn't launch from within an iFrame.
+
 ## 2.0.0 (2023-10-18)
 
 * **Note:** Includes all changes in [2.0.0-beta1](#200-beta1-2023-08-28)

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -94,7 +94,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         let script = WKUserScript(
             source: javascript,
             injectionTime: .atDocumentStart,
-            forMainFrameOnly: true
+            forMainFrameOnly: false
         )
         
         webView.configuration.userContentController.addUserScript(script)

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -22,7 +22,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let userScript = webView.configuration.userContentController.userScripts[0]
 
         XCTAssertEqual(userScript.injectionTime, WKUserScriptInjectionTime.atDocumentStart)
-        XCTAssertTrue(userScript.isForMainFrameOnly)
+        XCTAssertFalse(userScript.isForMainFrameOnly)
     }
 
 


### PR DESCRIPTION
### Summary of changes

 - Set `WKUserScript.forMainFrameOnly` to false - (see [Apple docs](https://developer.apple.com/documentation/webkit/wkuserscript/1537856-formainframeonly)) 
 - Tested with @ravishekhar's sample site https://ravishekhar.github.io/paypal-buttons/static/

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo @ravishekhar 
