### PR TITLE
Disable SSL validation WKWebView

### DIFF
--- a/Demo/Demo/Info.plist
+++ b/Demo/Demo/Info.plist
@@ -62,5 +62,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Demo/Demo/POPViewController.h
+++ b/Demo/Demo/POPViewController.h
@@ -1,5 +1,6 @@
 @import UIKit;
+#import <WebKit/WebKit.h>
 
-@interface POPViewController : UIViewController
+@interface POPViewController : UIViewController <WKNavigationDelegate>
 
 @end

--- a/Demo/Demo/POPViewController.m
+++ b/Demo/Demo/POPViewController.m
@@ -15,6 +15,7 @@
     [super viewDidLoad];
 
     self.webView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
+    self.webView.navigationDelegate = self;
 
     // 2. Create Popup Bridge.
     self.popupBridge = [[POPPopupBridge alloc] initWithWebView:self.webView];
@@ -29,6 +30,15 @@
 
 - (void)popupBridge:(POPPopupBridge *)bridge requestsDismissalOfViewController:(UIViewController *)viewController {
     [viewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler {
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
 }
 
 @end


### PR DESCRIPTION
### Summary of changes

 - Disable SSL validation for WKWebView. The Demo app's ViewController conforms to WKNavigationDelegate to accept SSL certificates without verifying their validity. 
 - Add the AppTransportSecurity key to the Demo App's info.plist.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @richherrera  
