### PR TITLE
[v3] Require xCode 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,25 +2,25 @@ name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 15.1)
-    runs-on: macOS-13
+    name: CocoaPods (Xcode 16.2.0)
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   spm:
-    name: SPM (Xcode 15.1)
-    runs-on: macOS-13
+    name: SPM (Xcode 16.2.0)
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-13
+    runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0..app
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,26 +2,26 @@ name: Tests
 on: [pull_request, workflow_dispatch]
 jobs:
   unit_test_job:
-    name: Unit (Xcode 15.1)
-    runs-on: macOS-13
+    name: Unit (Xcode 16.2.0)
+    runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0..app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 16,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
-    name: UI (Xcode 15.1)
-    runs-on: macOS-13
+    name: UI (Xcode 16.2.0)
+    runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Use Xcode 16.2.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
-        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 14,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
+        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PopupBridge iOS Release Notes
 
+## unreleased (v3)
+* Require Xcode 16.2.0+ and Swift 5.10+
+
 ## unreleased
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 

--- a/PopupBridge.podspec
+++ b/PopupBridge.podspec
@@ -19,7 +19,7 @@ Use cases for PopupBridge:
   s.source           = { :git => 'https://github.com/braintree/popup-bridge-ios.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '14.0'
-  s.swift_version    = "5.9"
+  s.swift_version    = "5.10"
   
   s.source_files = 'Sources/PopupBridge/**/*.swift'
   s.resource_bundle = { "PopupBridge_PrivacyInfo" => "Sources/PopupBridge/PrivacyInfo.xcprivacy" }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Requirements
 ------------
 
 - iOS 14.0+
-- Xcode 15.0+
-- Swift 5.9+, or Objective-C
+- Xcode 16.2.0+
+- Swift 5.10+, or Objective-C
 
 Installation
 ------------

--- a/V3_MIGRATION.md
+++ b/V3_MIGRATION.md
@@ -1,0 +1,7 @@
+# PopupBridge iOS v3 Migration Guide
+
+See the [CHANGELOG](/CHANGELOG.md) for a complete list of changes. This migration guide outlines the basics for updating your client integration from v2 to v3.
+
+## Supported Versions
+
+v3 supports a minimum deployment target of iOS 14+. It requires Xcode 16.2.0+ and Swift 5.10+. If your application contains Objective-C code, the `Enable Modules` build setting must be set to `YES`.


### PR DESCRIPTION
### Summary of changes

- Update all workflow to use Xcode 16.2.0 ([resource](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode))
- Bump up `Package.swift` and `PopupBridge.podspec` to use Swift 5.10
- Update CHANGELOG, MIGRATION Guide and README

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @richherrera 
