### PR TITLE
[V3] Expose `prefersEphemeralWebBrowserSession`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased (v3)
 * Bump minimum supported deployment target to iOS 16+
 * Require Xcode 16.2.0+ and Swift 5.10+
+* Add the `prefersEphemeralWebBrowserSession` property to the `POPPopupBridge` initializer, which specifies whether to request a private authentication session from the browser.
 
 ## 2.2.0  (2025-02-05)
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -22,12 +22,16 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// Initialize a Popup Bridge.
     /// - Parameters:
     ///   - webView: The web view to add a script message handler to. Do not change the web view's configuration or user content controller after initializing Popup Bridge.
-    public init(webView: WKWebView) {
+    ///   - prefersEphemeralWebBrowserSession: A Boolean that, when true, requests that the browser does not share cookies
+    ///   or other browsing data between the authenthication session and the user’s normal browser session.
+    ///   Defaults to `true`.
+    public init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true) {
         self.webView = webView
         
         super.init()
 
         configureWebView()
+        webAuthenticationSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
                 
         returnBlock = { url in
             guard let script = self.constructJavaScriptCompletionResult(returnURL: url) else {

--- a/Sources/PopupBridge/WebAuthenticationSession.swift
+++ b/Sources/PopupBridge/WebAuthenticationSession.swift
@@ -4,6 +4,7 @@ import AuthenticationServices
 class WebAuthenticationSession: NSObject {
 
     var authenticationSession: ASWebAuthenticationSession?
+    var prefersEphemeralWebBrowserSession: Bool = true
 
     func start(
         url: URL,
@@ -21,8 +22,7 @@ class WebAuthenticationSession: NSObject {
                 sessionDidComplete(url, error)
             }
         }
-
-        authenticationSession?.prefersEphemeralWebBrowserSession = true
+        authenticationSession?.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
         authenticationSession?.presentationContextProvider = context
 
         authenticationSession?.start()


### PR DESCRIPTION
### Summary of changes

 - Add the `prefersEphemeralWebBrowserSession` property to the `POPPopupBridge` initializer, which specifies whether to request a private authentication session from the browser.
 
prefersEphemeralWebBrowserSession:
| `true` | `false` |
|--------------|--------------|
| <video width="560" height="315" src="https://github.com/user-attachments/assets/a9fa5092-6aee-4e41-9de0-9229d1c3010d"> | <video width="560" height="315" src="https://github.com/user-attachments/assets/e0b99070-5d9e-47ce-b4b0-7f7767e13667"> |

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @richherrera 
