### PR TITLE
Move Started Event to Match Android

### DIFF
--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -100,6 +100,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// Injects custom JavaScript into the merchant's webpage.
     /// - Parameter scheme: the url scheme provided by the merchant
     private func configureWebView() {
+        Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.started, sessionID: sessionID)
         webView.configuration.userContentController.add(
             WebViewScriptHandler(proxy: self),
             name: messageHandlerName
@@ -142,7 +143,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             }
             
             if let urlString = script.url, let url = URL(string: urlString) {
-                Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.started, sessionID: sessionID)
                 webAuthenticationSession.start(url: url, context: self) { url, _ in
                     if let url, let returnBlock = self.returnBlock {
                         self.returnedWithURL = true

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -33,9 +33,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         self.webView = webView
         
         super.init()
-        
-        Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.started, sessionID: sessionID)
-        
+
         configureWebView()
         webAuthenticationSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
                 
@@ -144,6 +142,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             }
             
             if let urlString = script.url, let url = URL(string: urlString) {
+                Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.started, sessionID: sessionID)
                 webAuthenticationSession.start(url: url, context: self) { url, _ in
                     if let url, let returnBlock = self.returnBlock {
                         self.returnedWithURL = true

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -288,15 +288,38 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         return nil
     }
     
-    func testInit_sendsAnalytics() {
+    func testUserContentController_sendsAnalytics() {
         XCTAssertEqual(mockAnalyticsService.eventCount, 0)
         POPPopupBridge.analyticsService = mockAnalyticsService
         
-        let _ = POPPopupBridge(
-            webView: WKWebView(),
+        let configuration = WKWebViewConfiguration()
+        let mockUserContentController = MockUserContentController()
+
+        configuration.userContentController = mockUserContentController
+        
+        let stubMessageBody: [String: String] = ["url": "http://example.com/?hello=world"]
+        let stubMessageName = scriptMessageHandlerName
+        let stubMessage = MockScriptMessage()
+        stubMessage.body = stubMessageBody
+        stubMessage.name = stubMessageName
+
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
+        let pub = POPPopupBridge(
+            webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession
         )
 
+        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
+
+        webView.evaluateJavaScript("""
+        "if (typeof window.popupBridge.onCancel === 'function') {"
+        "  window.popupBridge.onCancel();"
+        "} else {"
+        "  window.popupBridge.onComplete(null, null);"
+        "}"
+        """)
+        
         XCTAssertEqual(mockAnalyticsService.eventCount, 1)
         XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.started)
         XCTAssertNotNil(mockAnalyticsService.lastSessionID)
@@ -325,7 +348,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let actualJSON = extractJSON(from: result!)
         
         XCTAssertEqual(actualJSON, expectedJSON)
-        XCTAssertEqual(mockAnalyticsService.eventCount, 2)
+        XCTAssertEqual(mockAnalyticsService.eventCount, 1)
         XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.succeeded)
         XCTAssertNotNil(mockAnalyticsService.lastSessionID)
     }

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -288,37 +288,14 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         return nil
     }
     
-    func testUserContentController_sendsAnalytics() {
+    func testInit_sendsAnalytics() {
         XCTAssertEqual(mockAnalyticsService.eventCount, 0)
         POPPopupBridge.analyticsService = mockAnalyticsService
         
-        let configuration = WKWebViewConfiguration()
-        let mockUserContentController = MockUserContentController()
-
-        configuration.userContentController = mockUserContentController
-        
-        let stubMessageBody: [String: String] = ["url": "http://example.com/?hello=world"]
-        let stubMessageName = scriptMessageHandlerName
-        let stubMessage = MockScriptMessage()
-        stubMessage.body = stubMessageBody
-        stubMessage.name = stubMessageName
-
-        POPPopupBridge.analyticsService = mockAnalyticsService
-        let webView = WKWebView(frame: CGRect(), configuration: configuration)
-        let pub = POPPopupBridge(
-            webView: webView,
+        let _ = POPPopupBridge(
+            webView: WKWebView(),
             webAuthenticationSession: mockWebAuthenticationSession
         )
-
-        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
-
-        webView.evaluateJavaScript("""
-        "if (typeof window.popupBridge.onCancel === 'function') {"
-        "  window.popupBridge.onCancel();"
-        "} else {"
-        "  window.popupBridge.onComplete(null, null);"
-        "}"
-        """)
         
         XCTAssertEqual(mockAnalyticsService.eventCount, 1)
         XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.started)
@@ -348,7 +325,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let actualJSON = extractJSON(from: result!)
         
         XCTAssertEqual(actualJSON, expectedJSON)
-        XCTAssertEqual(mockAnalyticsService.eventCount, 1)
+        XCTAssertEqual(mockAnalyticsService.eventCount, 2)
         XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.succeeded)
         XCTAssertNotNil(mockAnalyticsService.lastSessionID)
     }


### PR DESCRIPTION
### Summary of changes

 - Move started event to match Android implementation ([source code](https://github.com/braintree/popup-bridge-android/blob/28c04a0b483566a450e6152de6acd69c767e3853/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt#L143))

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 
