### PR TITLE
Updates the CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,25 +2,25 @@ name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
-    name: CocoaPods (Xcode 16.2.0)
+    name: CocoaPods (Xcode 16.4.0)
     runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   spm:
-    name: SPM (Xcode 16.2.0)
+    name: SPM (Xcode 16.4.0)
     runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Xcode 16.4.0
         run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Install CocoaPod dependencies
@@ -18,7 +18,7 @@ jobs:
     runs-on: macOS-15-xlarge
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Xcode 16.4.0
         run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Use current branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,25 +2,25 @@ name: Tests
 on: [pull_request, workflow_dispatch]
 jobs:
   unit_test_job:
-    name: Unit (Xcode 16.2.0)
+    name: Unit (Xcode 16.4.0)
     runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+        uses: actions/checkout@v4
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 16,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
   ui_test_job:
-    name: UI (Xcode 16.2.0)
+    name: UI (Xcode 16.4.0)
     runs-on: macOS-15-xlarge
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 16.2.0
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.0.app
+        uses: actions/checkout@v4
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests


### PR DESCRIPTION
### Summary of changes

Updates the CI workflows to use Xcode 16.4.0 and the latest version of the GitHub Actions checkout action. 

**CI/CD environment updates:**

* Updated all workflow jobs in `.github/workflows/build.yml`, `.github/workflows/tests.yml`, and `.github/workflows/release.yml` to use Xcode 16.4.0 instead of Xcode 16.2.0.
* Changed the GitHub Actions checkout step from `actions/checkout@v2` to `actions/checkout@v4` in all workflows for improved reliability and performance.

 ### Checklist

 - [ ] Added a changelog entry

### Authors

- @richherrera 
