### PR TITLE
[Feature] PopupBridge++

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,25 @@
 ### Summary of changes
+- 
 
- - 
+### AI Usage
 
- ### Checklist
+**Which AI Agent Was Used?**
+- [ ] Copilot 
+- [ ] Claude 
+- [ ] Other (Type Name Here)
 
- - [ ] Added a changelog entry
+**How was AI used?**
+<!-- Describe how AI was used (e.g., code generation, refactoring, debugging, writing tests, etc.) -->
+
+**Estimated AI Code Contribution**
+- [ ] less than 30% 
+- [ ] 30 - 60% 
+- [ ] 60 - 100% 
+
+### Checklist
+- [ ] Added a changelog entry
+- [ ] Tested and confirmed payment flows affected by this change are functioning as expected
 
 ### Authors
 > List GitHub usernames for everyone who contributed to this pull request.
-
-- 
+-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Xcode 16.4.0
         run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
       - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+        run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,15 @@ jobs:
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 16,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify
+  integration_test_job:
+    name: Integration (Xcode 16.4.0)
+    runs-on: macOS-15-xlarge
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Use Xcode 16.4.0
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app
+      - name: Install CocoaPod dependencies
+        run: pod install
+      - name: Run Integration Tests
+        run: set -o pipefail && xcodebuild -workspace 'PopupBridge.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'IntegrationTests' -destination 'name=iPhone 16,platform=iOS Simulator' test | ./Pods/xcbeautify/xcbeautify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PopupBridge iOS Release Notes
 
+## unreleased
+
+* Add optional `enablePopupBridgeAppSwitch` flag to `POPPopupBridge` initializer. When enabled, the SDK attempts to launch the native PayPal app for checkout instead of opening a browser session. Falls back to `ASWebAuthenticationSession` if the app launch fails.
+* Expose `isPayPalInstalled`, `launchApp()`, and `getDeepLinkReturnUrlPrefix()` on `window.popupBridge` in JavaScript.
+
 ## 3.0.0 (2025-04-01)
 * Breaking Changes
   * Bump minimum supported deployment target to iOS 16+

--- a/IntegrationTests/AnalyticsService_IntegrationTests.swift
+++ b/IntegrationTests/AnalyticsService_IntegrationTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import PopupBridge
+
+final class AnalyticsService_IntegrationTests: XCTestCase {
+
+    var sut: AnalyticsService!
+
+    let eventName = "test-integration-event"
+    let sessionID = "test-integration-session-id"
+    let analyticsURL = URL(string: "https://api.paypal.com/v1/tracking/batch/events")!
+
+    override func setUp() {
+        super.setUp()
+        StubURLProtocol.reset()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        sut = AnalyticsService(session: URLSession(configuration: config))
+    }
+
+    override func tearDown() {
+        sut = nil
+        StubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - performEventRequest
+
+    func test_performEventRequest_success_postsToCorrectEndpointWithCorrectPayload() async {
+        StubURLProtocol.stubbedStatusCode = 200
+
+        await sut.performEventRequest(eventName, sessionID: sessionID)
+
+        XCTAssertEqual(StubURLProtocol.lastRequest?.url, analyticsURL)
+        XCTAssertEqual(StubURLProtocol.lastRequest?.httpMethod, "POST")
+        XCTAssertEqual(StubURLProtocol.lastRequest?.allHTTPHeaderFields?["Content-Type"], "application/json")
+
+        guard let body = StubURLProtocol.lastRequest?.httpBody,
+              let decoded = try? JSONDecoder().decode(FPTIBatchData.self, from: body) else {
+            XCTFail("Request body could not be decoded as FPTIBatchData")
+            return
+        }
+        XCTAssertEqual(decoded.events.first?.fptiEvents.first?.eventName, eventName)
+        XCTAssertEqual(decoded.events.first?.metadata.sessionID, sessionID)
+    }
+
+    func test_performEventRequest_nonSuccessResponse_doesNotPropagateError() async {
+        StubURLProtocol.stubbedStatusCode = 400
+
+        await sut.performEventRequest(eventName, sessionID: sessionID)
+
+        XCTAssertNotNil(StubURLProtocol.lastRequest, "Request should have been sent despite error response")
+    }
+
+    func test_performEventRequest_serverError_doesNotPropagateError() async {
+        StubURLProtocol.stubbedStatusCode = 500
+
+        await sut.performEventRequest(eventName, sessionID: sessionID)
+
+        XCTAssertNotNil(StubURLProtocol.lastRequest)
+    }
+
+    // MARK: - sendAnalyticsEvent
+
+    func test_sendAnalyticsEvent_dispatchesNetworkRequestInBackground() async {
+        StubURLProtocol.stubbedStatusCode = 200
+        let expectation = expectation(description: "Stub received the analytics request")
+        StubURLProtocol.onRequest = { _ in expectation.fulfill() }
+
+        sut.sendAnalyticsEvent(eventName, sessionID: sessionID)
+
+        await fulfillment(of: [expectation], timeout: 10.0)
+        XCTAssertEqual(StubURLProtocol.lastRequest?.url, analyticsURL)
+    }
+}

--- a/IntegrationTests/Info.plist
+++ b/IntegrationTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/IntegrationTests/Mocks/MockScriptMessage.swift
+++ b/IntegrationTests/Mocks/MockScriptMessage.swift
@@ -1,0 +1,17 @@
+import WebKit
+
+final class MockScriptMessage: WKScriptMessage {
+
+    var stubName: String = ""
+    var stubBody: Any = [:]
+
+    override var name: String {
+        get { stubName }
+        set { stubName = newValue }
+    }
+
+    override var body: Any {
+        get { stubBody }
+        set { stubBody = newValue }
+    }
+}

--- a/IntegrationTests/Mocks/MockWebAuthSession.swift
+++ b/IntegrationTests/Mocks/MockWebAuthSession.swift
@@ -1,0 +1,18 @@
+import AuthenticationServices
+@testable import PopupBridge
+
+final class MockWebAuthSession: WebAuthenticationSession {
+
+    var startWasCalled = false
+    var capturedURL: URL?
+
+    override func start(
+        url: URL,
+        context: ASWebAuthenticationPresentationContextProviding,
+        sessionDidComplete: @escaping (URL?, Error?) -> Void,
+        sessionDidCancel: @escaping () -> Void
+    ) {
+        startWasCalled = true
+        capturedURL = url
+    }
+}

--- a/IntegrationTests/Mocks/StubURLProtocol.swift
+++ b/IntegrationTests/Mocks/StubURLProtocol.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+final class StubURLProtocol: URLProtocol {
+
+    static var stubbedStatusCode: Int = 200
+    static var lastRequest: URLRequest?
+    static var onRequest: ((URLRequest) -> Void)?
+
+    static func reset() {
+        stubbedStatusCode = 200
+        lastRequest = nil
+        onRequest = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var capturedRequest = request
+        if capturedRequest.httpBody == nil, let stream = capturedRequest.httpBodyStream {
+            var data = Data()
+            stream.open()
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            while stream.hasBytesAvailable {
+                let count = stream.read(buffer, maxLength: 4096)
+                if count > 0 { data.append(buffer, count: count) }
+            }
+            buffer.deallocate()
+            stream.close()
+            capturedRequest.httpBody = data
+        }
+        Self.lastRequest = capturedRequest
+        Self.onRequest?(capturedRequest)
+        guard let url = request.url,
+              let httpResponse = HTTPURLResponse(
+                url: url,
+                statusCode: Self.stubbedStatusCode,
+                httpVersion: nil,
+                headerFields: nil
+              ) else { return }
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/IntegrationTests/PopupBridge_IntegrationTests.swift
+++ b/IntegrationTests/PopupBridge_IntegrationTests.swift
@@ -1,0 +1,145 @@
+import AuthenticationServices
+import XCTest
+import WebKit
+@testable import PopupBridge
+
+final class PopupBridge_IntegrationTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        StubURLProtocol.reset()
+        POPPopupBridge.analyticsService = AnalyticsService()
+    }
+
+    override func tearDown() {
+        StubURLProtocol.reset()
+        POPPopupBridge.analyticsService = AnalyticsService()
+        super.tearDown()
+    }
+
+    // MARK: - init
+
+    func test_init_withRealWKWebView_injectsUserScriptAtDocumentStart() {
+        let webView = WKWebView()
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 0)
+
+        let _ = POPPopupBridge(webView: webView)
+
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 1)
+        XCTAssertEqual(webView.configuration.userContentController.userScripts[0].injectionTime, .atDocumentStart)
+        XCTAssertFalse(webView.configuration.userContentController.userScripts[0].isForMainFrameOnly)
+    }
+
+    @MainActor
+    func test_init_withRealAnalyticsService_sendsStartedEvent() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubURLProtocol.self]
+        POPPopupBridge.analyticsService = AnalyticsService(session: URLSession(configuration: config))
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var resumed = false
+            StubURLProtocol.onRequest = { request in
+                guard let body = request.httpBody,
+                      let decoded = try? JSONDecoder().decode(FPTIBatchData.self, from: body),
+                      decoded.events.first?.fptiEvents.first?.eventName == PopupBridgeAnalytics.started,
+                      !resumed else { return }
+                resumed = true
+                continuation.resume()
+            }
+            let _ = POPPopupBridge(webView: WKWebView())
+        }
+    }
+
+    // MARK: - userContentController
+
+    func test_userContentController_withNonJSONSerializableBody_returnsEarlyWithoutStartingSession() {
+        let webView = WKWebView()
+        let mockSession = MockWebAuthSession()
+        let bridge = POPPopupBridge(webView: webView, webAuthenticationSession: mockSession)
+
+        let message = MockScriptMessage()
+        message.stubName = "POPPopupBridge"
+        message.stubBody = ["this-is-an-array-not-a-dict"]
+
+        bridge.userContentController(WKUserContentController(), didReceive: message)
+
+        XCTAssertFalse(mockSession.startWasCalled, "ASWebAuthenticationSession should not start for a non-JSON-serializable message body")
+    }
+
+    func test_userContentController_withMessageMissingURL_doesNotStartSession() {
+        let webView = WKWebView()
+        let mockSession = MockWebAuthSession()
+        let bridge = POPPopupBridge(webView: webView, webAuthenticationSession: mockSession)
+
+        let message = MockScriptMessage()
+        message.stubName = "POPPopupBridge"
+        message.stubBody = ["key": "value"]
+
+        bridge.userContentController(WKUserContentController(), didReceive: message)
+
+        XCTAssertFalse(mockSession.startWasCalled, "ASWebAuthenticationSession should not start when the message body has no URL")
+    }
+
+    func test_userContentController_withValidURL_startsSession() {
+        let webView = WKWebView()
+        let mockSession = MockWebAuthSession()
+        let bridge = POPPopupBridge(webView: webView, webAuthenticationSession: mockSession)
+
+        let message = MockScriptMessage()
+        message.stubName = "POPPopupBridge"
+        message.stubBody = ["url": "https://example.com/auth"]
+
+        bridge.userContentController(WKUserContentController(), didReceive: message)
+
+        XCTAssertTrue(mockSession.startWasCalled, "ASWebAuthenticationSession should start for a message with a valid URL")
+        XCTAssertEqual(mockSession.capturedURL, URL(string: "https://example.com/auth"))
+    }
+
+    // MARK: - constructJavaScriptCompletionResult
+
+    func test_constructJavaScriptCompletionResult_validURL_returnsOnCompleteScript() {
+        let bridge = POPPopupBridge(webView: WKWebView())
+        let url = URL(string: "\(PopupBridgeConstants.callbackURLScheme)://popupbridgev1/return?color=red")!
+
+        let result = bridge.constructJavaScriptCompletionResult(returnURL: url)
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.hasPrefix("window.popupBridge.onComplete(null,"))
+        XCTAssertTrue(result!.contains("\"path\":\"\\/return\""))
+    }
+
+    func test_constructJavaScriptCompletionResult_wrongScheme_returnsNil() {
+        let bridge = POPPopupBridge(webView: WKWebView())
+        let url = URL(string: "https://popupbridgev1/return?color=red")!
+
+        XCTAssertNil(bridge.constructJavaScriptCompletionResult(returnURL: url))
+    }
+
+    func test_constructJavaScriptCompletionResult_wrongHost_returnsNil() {
+        let bridge = POPPopupBridge(webView: WKWebView())
+        let url = URL(string: "\(PopupBridgeConstants.callbackURLScheme)://differenthost/return?color=red")!
+
+        XCTAssertNil(bridge.constructJavaScriptCompletionResult(returnURL: url))
+    }
+
+    func test_constructJavaScriptCompletionResult_withQueryParams_includesThemInPayload() {
+        let bridge = POPPopupBridge(webView: WKWebView())
+        let url = URL(string: "\(PopupBridgeConstants.callbackURLScheme)://popupbridgev1/return?token=abc&status=success")!
+
+        let result = bridge.constructJavaScriptCompletionResult(returnURL: url)
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.contains("token"))
+        XCTAssertTrue(result!.contains("abc"))
+    }
+
+    func test_constructJavaScriptCompletionResult_withFragment_includesHashInPayload() {
+        let bridge = POPPopupBridge(webView: WKWebView())
+        let url = URL(string: "\(PopupBridgeConstants.callbackURLScheme)://popupbridgev1/return#section=top")!
+
+        let result = bridge.constructJavaScriptCompletionResult(returnURL: url)
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.contains("section=top"))
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,10 @@ workspace 'PopupBridge.xcworkspace'
 
 use_frameworks!
 
+target 'IntegrationTests' do
+  project 'PopupBridge'
+end
+
 target 'UnitTests' do
   project 'PopupBridge'
   pod 'xcbeautify'

--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		451348272D8CAD7C009265C9 /* WebViewScriptHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451348262D8CAD6D009265C9 /* WebViewScriptHandler.swift */; };
 		4513482B2D8DDA25009265C9 /* XCTestCase+trackForMemoryLeaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513482A2D8DDA17009265C9 /* XCTestCase+trackForMemoryLeaks.swift */; };
 		45AE41D22D7649F800388548 /* MockAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE41D12D7649EE00388548 /* MockAnalyticsService.swift */; };
+		2E366BA6BAAD47F59451C258 /* MockURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD9F83E50044083861D6B42 /* MockURLOpener.swift */; };
 		45CD0C2C2D64F08F0072C5A4 /* FPTIBatchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CD0C2B2D64F0810072C5A4 /* FPTIBatchData.swift */; };
 		45CD0C2E2D664D140072C5A4 /* Date+MilisecondTimestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CD0C2D2D664CF50072C5A4 /* Date+MilisecondTimestamp.swift */; };
 		45CD0C302D6788A10072C5A4 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CD0C2F2D67888F0072C5A4 /* Bundle+Extension.swift */; };
@@ -42,6 +43,7 @@
 		451348262D8CAD6D009265C9 /* WebViewScriptHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewScriptHandler.swift; sourceTree = "<group>"; };
 		4513482A2D8DDA17009265C9 /* XCTestCase+trackForMemoryLeaks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+trackForMemoryLeaks.swift"; sourceTree = "<group>"; };
 		45AE41D12D7649EE00388548 /* MockAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsService.swift; sourceTree = "<group>"; };
+		9AD9F83E50044083861D6B42 /* MockURLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLOpener.swift; sourceTree = "<group>"; };
 		45CD0C2B2D64F0810072C5A4 /* FPTIBatchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FPTIBatchData.swift; sourceTree = "<group>"; };
 		45CD0C2D2D664CF50072C5A4 /* Date+MilisecondTimestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+MilisecondTimestamp.swift"; sourceTree = "<group>"; };
 		45CD0C2F2D67888F0072C5A4 /* Bundle+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				45AE41D12D7649EE00388548 /* MockAnalyticsService.swift */,
 				BE2524552A17FB9F00168D77 /* MockScriptMessage.swift */,
 				45FBAF2E2D701E1D000D550B /* MockSessionable.swift */,
+				9AD9F83E50044083861D6B42 /* MockURLOpener.swift */,
 				BE2524532A17DFCC00168D77 /* MockUserContentController.swift */,
 				BEF9ED202A2A4896005D54AB /* MockWebAuthenticationSession.swift */,
 				BE2524512A17DF8200168D77 /* PopupBridge_UnitTests.swift */,
@@ -356,6 +359,7 @@
 				BE2524542A17DFCC00168D77 /* MockUserContentController.swift in Sources */,
 				4513482B2D8DDA25009265C9 /* XCTestCase+trackForMemoryLeaks.swift in Sources */,
 				45AE41D22D7649F800388548 /* MockAnalyticsService.swift in Sources */,
+				2E366BA6BAAD47F59451C258 /* MockURLOpener.swift in Sources */,
 				BE2524562A17FB9F00168D77 /* MockScriptMessage.swift in Sources */,
 				BEF9ED212A2A4896005D54AB /* MockWebAuthenticationSession.swift in Sources */,
 				BE2524522A17DF8200168D77 /* PopupBridge_UnitTests.swift in Sources */,

--- a/PopupBridge.xcodeproj/project.pbxproj
+++ b/PopupBridge.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		085C05B32F9A78E000460CD9 /* MockWebAuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085C05B22F9A78E000460CD9 /* MockWebAuthSession.swift */; };
+		085C05B82F9A79DA00460CD9 /* MockScriptMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085C05B72F9A79DA00460CD9 /* MockScriptMessage.swift */; };
+		085C05BA2F9A7AB900460CD9 /* StubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085C05B92F9A7AB900460CD9 /* StubURLProtocol.swift */; };
 		451348272D8CAD7C009265C9 /* WebViewScriptHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451348262D8CAD6D009265C9 /* WebViewScriptHandler.swift */; };
 		4513482B2D8DDA25009265C9 /* XCTestCase+trackForMemoryLeaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4513482A2D8DDA17009265C9 /* XCTestCase+trackForMemoryLeaks.swift */; };
 		45AE41D22D7649F800388548 /* MockAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE41D12D7649EE00388548 /* MockAnalyticsService.swift */; };
@@ -23,11 +26,13 @@
 		45FC74C22D8347B500E50035 /* UIApplication+URLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FC74C12D8347AA00E50035 /* UIApplication+URLOpener.swift */; };
 		62D5EC522B9F753100D09C5D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62D5EC512B9F753100D09C5D /* PrivacyInfo.xcprivacy */; };
 		79DB9F7F53319F206CDE119E /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28245E4F1AC5126D54985D88 /* Pods_UnitTests.framework */; };
+		7D858B7D18224B72A392F86D /* PopupBridge_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15D038B71F540B38D21330B /* PopupBridge_IntegrationTests.swift */; };
 		800A09D82995F143003ED16E /* POPPopupBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A09D72995F143003ED16E /* POPPopupBridge.swift */; };
 		800E789D29E0958A00D1B0FC /* WebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E789C29E0958A00D1B0FC /* WebViewMessage.swift */; };
 		800E789F29E09A2A00D1B0FC /* URLDetailsPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E789E29E09A2A00D1B0FC /* URLDetailsPayload.swift */; };
 		804CC12D25AE1C5B0015D5D7 /* PopupBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A775A08B1DEE4EF0009E67C2 /* PopupBridge.framework */; };
 		8079D71A2996F6C200A2E336 /* PopupBridgeUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8079D7192996F6C200A2E336 /* PopupBridgeUserScript.swift */; };
+		956F069A1D8A232E4559DCE8 /* Pods_IntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E8EC6AA38C749E1E41AD21F /* Pods_IntegrationTests.framework */; };
 		A775A0931DEE4F14009E67C2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		A775A0941DEE4F18009E67C2 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7E9D6D21DCA6B540035FA41 /* SafariServices.framework */; };
 		BE2524522A17DF8200168D77 /* PopupBridge_UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2524512A17DF8200168D77 /* PopupBridge_UnitTests.swift */; };
@@ -36,10 +41,17 @@
 		BE8E37B62A17B79E00181FDA /* WebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8E37B52A17B79E00181FDA /* WebAuthenticationSession.swift */; };
 		BEF9ED212A2A4896005D54AB /* MockWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF9ED202A2A4896005D54AB /* MockWebAuthenticationSession.swift */; };
 		BEF9ED232A2A6A2C005D54AB /* PopupBridgeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF9ED222A2A6A2C005D54AB /* PopupBridgeConstants.swift */; };
+		C61FBBE25F5A4996BC02B34C /* AnalyticsService_IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F246C47404D63BFDBD807 /* AnalyticsService_IntegrationTests.swift */; };
+		EA53B8890E7546CDAF33FB88 /* PopupBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A775A08B1DEE4EF0009E67C2 /* PopupBridge.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		085C05B22F9A78E000460CD9 /* MockWebAuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebAuthSession.swift; sourceTree = "<group>"; };
+		085C05B72F9A79DA00460CD9 /* MockScriptMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScriptMessage.swift; sourceTree = "<group>"; };
+		085C05B92F9A7AB900460CD9 /* StubURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubURLProtocol.swift; sourceTree = "<group>"; };
 		28245E4F1AC5126D54985D88 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E8EC6AA38C749E1E41AD21F /* Pods_IntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3745CD9DA73C2F9226FF4C9E /* Pods-IntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		451348262D8CAD6D009265C9 /* WebViewScriptHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewScriptHandler.swift; sourceTree = "<group>"; };
 		4513482A2D8DDA17009265C9 /* XCTestCase+trackForMemoryLeaks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+trackForMemoryLeaks.swift"; sourceTree = "<group>"; };
 		45AE41D12D7649EE00388548 /* MockAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsService.swift; sourceTree = "<group>"; };
@@ -54,6 +66,7 @@
 		45FBAF2E2D701E1D000D550B /* MockSessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionable.swift; sourceTree = "<group>"; };
 		45FBAF342D70CFB6000D550B /* AnalyticsService_Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService_Test.swift; sourceTree = "<group>"; };
 		45FC74C12D8347AA00E50035 /* UIApplication+URLOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLOpener.swift"; sourceTree = "<group>"; };
+		4835FFC8BC524B9E85F05C68 /* IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EF7C7DDAB0B99FF28DD6541 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -64,6 +77,8 @@
 		800E789C29E0958A00D1B0FC /* WebViewMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewMessage.swift; sourceTree = "<group>"; };
 		800E789E29E09A2A00D1B0FC /* URLDetailsPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDetailsPayload.swift; sourceTree = "<group>"; };
 		8079D7192996F6C200A2E336 /* PopupBridgeUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupBridgeUserScript.swift; sourceTree = "<group>"; };
+		99BD69466A25C4F26B335778 /* Pods-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-IntegrationTests/Pods-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A15D038B71F540B38D21330B /* PopupBridge_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupBridge_IntegrationTests.swift; sourceTree = "<group>"; };
 		A71371AF1DCD429100D03A5C /* PopupBridge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PopupBridge.framework; path = "Pods/../build/Debug-iphoneos/PopupBridge/PopupBridge.framework"; sourceTree = "<group>"; };
 		A73D5A081DFA2E9A00387737 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		A73D5A091DFA2E9A00387737 /* PopupBridge.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = PopupBridge.podspec; sourceTree = "<group>"; };
@@ -80,10 +95,21 @@
 		BE8E37B52A17B79E00181FDA /* WebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthenticationSession.swift; sourceTree = "<group>"; };
 		BEF9ED202A2A4896005D54AB /* MockWebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebAuthenticationSession.swift; sourceTree = "<group>"; };
 		BEF9ED222A2A6A2C005D54AB /* PopupBridgeConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupBridgeConstants.swift; sourceTree = "<group>"; };
+		D83F246C47404D63BFDBD807 /* AnalyticsService_IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService_IntegrationTests.swift; sourceTree = "<group>"; };
+		DEF9F85E82244B51BD3B7C10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E5E5F02D55D023487C75A22D /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		6F588C4C4E2744B8ADAEB1CC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA53B8890E7546CDAF33FB88 /* PopupBridge.framework in Frameworks */,
+				956F069A1D8A232E4559DCE8 /* Pods_IntegrationTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A775A0791DEE4E7E009E67C2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -105,11 +131,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		085C05B62F9A79AF00460CD9 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				085C05B22F9A78E000460CD9 /* MockWebAuthSession.swift */,
+				085C05B72F9A79DA00460CD9 /* MockScriptMessage.swift */,
+				085C05B92F9A7AB900460CD9 /* StubURLProtocol.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
 		089BA8CF5FAA4A7D83B81A93 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
 				4EF7C7DDAB0B99FF28DD6541 /* Pods-UnitTests.debug.xcconfig */,
 				E5E5F02D55D023487C75A22D /* Pods-UnitTests.release.xcconfig */,
+				99BD69466A25C4F26B335778 /* Pods-IntegrationTests.debug.xcconfig */,
+				3745CD9DA73C2F9226FF4C9E /* Pods-IntegrationTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -129,6 +167,7 @@
 			children = (
 				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
 				806F552D25B13211001754AF /* Sources */,
+				C3CD7FDCB49E48EDA23A7970 /* IntegrationTests */,
 				A775A07D1DEE4E7E009E67C2 /* UnitTests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
@@ -139,6 +178,7 @@
 		6003F58B195388D20070C39A /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				4835FFC8BC524B9E85F05C68 /* IntegrationTests.xctest */,
 				A775A07C1DEE4E7E009E67C2 /* UnitTests.xctest */,
 				A775A08B1DEE4EF0009E67C2 /* PopupBridge.framework */,
 			);
@@ -156,6 +196,7 @@
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				28245E4F1AC5126D54985D88 /* Pods_UnitTests.framework */,
+				2E8EC6AA38C749E1E41AD21F /* Pods_IntegrationTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -217,6 +258,17 @@
 			path = PopupBridge;
 			sourceTree = "<group>";
 		};
+		C3CD7FDCB49E48EDA23A7970 /* IntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				085C05B62F9A79AF00460CD9 /* Mocks */,
+				D83F246C47404D63BFDBD807 /* AnalyticsService_IntegrationTests.swift */,
+				DEF9F85E82244B51BD3B7C10 /* Info.plist */,
+				A15D038B71F540B38D21330B /* PopupBridge_IntegrationTests.swift */,
+			);
+			path = IntegrationTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -230,6 +282,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3158BD13B646433F81C084D9 /* IntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BBE365834D474AEFA050B92F /* Build configuration list for PBXNativeTarget "IntegrationTests" */;
+			buildPhases = (
+				D0FEE423411A9626314EE345 /* [CP] Check Pods Manifest.lock */,
+				23BBF50BB81E4B03B1571328 /* Sources */,
+				6F588C4C4E2744B8ADAEB1CC /* Frameworks */,
+				7B8CF73CA4C04951BD425A81 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationTests;
+			productName = IntegrationTests;
+			productReference = 4835FFC8BC524B9E85F05C68 /* IntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		A775A07B1DEE4E7E009E67C2 /* UnitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A775A0851DEE4E7E009E67C2 /* Build configuration list for PBXNativeTarget "UnitTests" */;
@@ -276,6 +346,10 @@
 				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = Braintree;
 				TargetAttributes = {
+					3158BD13B646433F81C084D9 = {
+						CreatedOnToolsVersion = 1420;
+						ProvisioningStyle = Automatic;
+					};
 					A775A07B1DEE4E7E009E67C2 = {
 						CreatedOnToolsVersion = 8.1;
 						LastSwiftMigration = 1420;
@@ -301,6 +375,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				3158BD13B646433F81C084D9 /* IntegrationTests */,
 				A775A07B1DEE4E7E009E67C2 /* UnitTests */,
 				A775A08A1DEE4EF0009E67C2 /* PopupBridge */,
 			);
@@ -308,6 +383,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		7B8CF73CA4C04951BD425A81 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A775A07A1DEE4E7E009E67C2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -348,9 +430,43 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		D0FEE423411A9626314EE345 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-IntegrationTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		23BBF50BB81E4B03B1571328 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C61FBBE25F5A4996BC02B34C /* AnalyticsService_IntegrationTests.swift in Sources */,
+				7D858B7D18224B72A392F86D /* PopupBridge_IntegrationTests.swift in Sources */,
+				085C05BA2F9A7AB900460CD9 /* StubURLProtocol.swift in Sources */,
+				085C05B82F9A79DA00460CD9 /* MockScriptMessage.swift in Sources */,
+				085C05B32F9A78E000460CD9 /* MockWebAuthSession.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A775A0781DEE4E7E009E67C2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -392,6 +508,31 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		18F85E90172A4C8397CBEEB3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3745CD9DA73C2F9226FF4C9E /* Pods-IntegrationTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = IntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.braintreepayments.PopupBridge-IntegrationTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		6003F5BD195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -494,6 +635,31 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		83919E4E51904F2887F37D76 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 99BD69466A25C4F26B335778 /* Pods-IntegrationTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = IntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.braintreepayments.PopupBridge-IntegrationTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
 		};
 		A775A0831DEE4E7E009E67C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -641,6 +807,15 @@
 			buildConfigurations = (
 				A775A0911DEE4EF0009E67C2 /* Debug */,
 				A775A0921DEE4EF0009E67C2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BBE365834D474AEFA050B92F /* Build configuration list for PBXNativeTarget "IntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83919E4E51904F2887F37D76 /* Debug */,
+				18F85E90172A4C8397CBEEB3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PopupBridge.xcodeproj/xcshareddata/xcschemes/IntegrationTests.xcscheme
+++ b/PopupBridge.xcodeproj/xcshareddata/xcschemes/IntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -17,10 +17,10 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "806D55B325AFD877005ED326"
-               BuildableName = "UITests.xctest"
-               BlueprintName = "UITests"
-               ReferencedContainer = "container:Demo.xcodeproj">
+               BlueprintIdentifier = "3158BD13B646433F81C084D9"
+               BuildableName = "IntegrationTests.xctest"
+               BlueprintName = "IntegrationTests"
+               ReferencedContainer = "container:PopupBridge.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+This repository adheres to the [PayPal Vulnerability Reporting Policy](https://hackerone.com/paypal).
+
+## Reporting a Vulnerability
+
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
+
+Instead, report it using one of the following ways:
+
+* Email the PayPal Security Team at [security@paypal.com](mailto:security@paypal.com)
+* Submit through the [PayPal Bug Bounty Program](https://hackerone.com/paypal) on HackerOne
+* Report a [vulnerability](https://github.com/braintree/popup-bridge-ios/security/advisories/new) directly via private vulnerability reporting on GitHub
+
+Please include the following in your report:
+
+* The type of issue and affected version(s)
+* Step-by-step instructions to reproduce the issue
+* Impact of the issue and how an attacker might exploit it
+
+## Supported Security Updates
+
+### Security Issues
+
+Only the latest release series receives patches and new versions in the case of a security issue. See our [deprecation policy](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/ios/v7/) for details.
+
+### Severe Security Issues
+
+For severe security issues, we will provide new versions as above. Additionally, the last major release series may receive patches at our discretion. Severity classification is determined by the Braintree SDK team.
+
+### Platform Support
+
+| Platform | Supported Versions                          |
+| -------- | ------------------------------------------- |
+| iOS      | Most recent version and 2 previous versions |
+
+For details on supported platform versions, see our [deprecation policy](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/ios/v7/).
+
+## Disclosure Policy
+
+We are committed to working with security researchers in good faith. To support responsible disclosure, our team will:
+
+- Acknowledge your report in a timely manner
+- Keep you informed of our progress toward a fix
+- Notify you before any public disclosure
+
+We ask that you:
+
+- Do not publicly disclose the issue before it has been resolved
+- Avoid accessing, modifying, or deleting data that does not belong to you
+- Make a good faith effort to avoid disruption to production systems
+
+We appreciate responsible disclosure and your efforts to keep Braintree SDK users safe.

--- a/Sources/PopupBridge/Analytics/AnalyticsService.swift
+++ b/Sources/PopupBridge/Analytics/AnalyticsService.swift
@@ -22,7 +22,7 @@ final class AnalyticsService: AnalyticsServiceable {
     
     func sendAnalyticsEvent(_ eventName: String, sessionID: String) {
         Task(priority: .background) {
-            await performEventRequest(eventName, sessionID: sessionID)
+            await self.performEventRequest(eventName, sessionID: sessionID)
         }
     }
     

--- a/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
+++ b/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
@@ -1,8 +1,14 @@
 enum PopupBridgeAnalytics {
-    
+
     static let started = "popup-bridge:started"
     static let succeeded = "popup-bridge:succeeded"
     static let failed = "popup-bridge:failed"
     static let canceled = "popup-bridge:canceled"
+
+    static let paypalInstalled = "popup-bridge:app-detection:paypal-installed"
+    static let paypalNotInstalled = "popup-bridge:app-detection:paypal-not-installed"
+    static let appLaunchStarted = "popup-bridge:app-launch:started"
+    static let appLaunchSucceeded = "popup-bridge:app-launch:succeeded"
+    static let appLaunchFailed = "popup-bridge:app-launch:failed"
 }
 

--- a/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
+++ b/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
@@ -3,10 +3,7 @@ enum PopupBridgeAnalytics {
     static let succeeded = "popup-bridge:succeeded"
     static let failed = "popup-bridge:failed"
     static let canceled = "popup-bridge:canceled"
-    static let paypalInstalled = "popup-bridge:app-detection:paypal-installed"
-    static let paypalNotInstalled = "popup-bridge:app-detection:paypal-not-installed"
     static let appLaunchStarted = "popup-bridge:app-launch:started"
     static let appLaunchSucceeded = "popup-bridge:app-launch:succeeded"
     static let appLaunchFailed = "popup-bridge:app-launch:failed"
 }
-

--- a/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
+++ b/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
@@ -1,5 +1,4 @@
 enum PopupBridgeAnalytics {
-
     static let started = "popup-bridge:started"
     static let succeeded = "popup-bridge:succeeded"
     static let failed = "popup-bridge:failed"

--- a/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
+++ b/Sources/PopupBridge/Analytics/PopupBridgeAnalytics.swift
@@ -3,7 +3,6 @@ enum PopupBridgeAnalytics {
     static let succeeded = "popup-bridge:succeeded"
     static let failed = "popup-bridge:failed"
     static let canceled = "popup-bridge:canceled"
-
     static let paypalInstalled = "popup-bridge:app-detection:paypal-installed"
     static let paypalNotInstalled = "popup-bridge:app-detection:paypal-not-installed"
     static let appLaunchStarted = "popup-bridge:app-launch:started"

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -131,10 +131,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     }
 
     /// Parses the return URL and injects `window.popupBridge.onComplete()` into the WebView.
-    /// Venice uses fragment-based return for web_sdk integration:
+    /// Venice may return fragment-based data for web_sdk integration:
     ///   merchantapp://popupbridgev1/onApprove#onApprove&PayerID=XXX&token=EC-YYY
-    /// The fragment contains key=value pairs that must be merged into queryItems
-    /// since the JS SDK reads result.queryItems (not result.hash).
+    /// The JS SDK is responsible for normalizing `path`, `queryItems`, and `hash`.
     private func handleLaunchAppReturn(url: URL) {
         NSLog(
             "[tanya] POPPopupBridge.handleLaunchAppReturn ENTER: sessionID=%@ url=%@ time=%@",
@@ -153,32 +152,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             return
         }
 
-        var queryItems = urlComponents.queryItems?.reduce(into: [String: String]()) { partialResult, queryItem in
+        let queryItems = urlComponents.queryItems?.reduce(into: [String: String]()) { partialResult, queryItem in
             partialResult[queryItem.name] = queryItem.value
         } ?? [:]
-
-        // Parse fragment params (e.g. "onApprove&PayerID=XXX&token=EC-YYY") and merge
-        if let fragment = urlComponents.fragment {
-            let fragmentComponents = fragment.components(separatedBy: "&")
-            for component in fragmentComponents {
-                let parts = component.components(separatedBy: "=")
-                if parts.count == 2 {
-                    queryItems[parts[0]] = parts[1].removingPercentEncoding ?? parts[1]
-                }
-            }
-        }
-
-        // Map the path to the opType expected by the JS SDK's popup-bridge payment flow.
-        // Venice returns /onApprove or /onCancel in the path; the JS SDK expects
-        // opType "payment" or "cancel" respectively.
-        if queryItems["opType"] == nil {
-            let path = urlComponents.path.lowercased()
-            if path.contains("onapprove") {
-                queryItems["opType"] = "payment"
-            } else if path.contains("oncancel") {
-                queryItems["opType"] = "cancel"
-            }
-        }
 
         let payload = URLDetailsPayload(
             path: urlComponents.path,

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -16,13 +16,13 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private let hostName = "popupbridgev1"
     private let sessionID = UUID().uuidString.replacingOccurrences(of: "-", with: "")
     private let webView: WKWebView
-    private var application: URLOpener = UIApplication.shared
+    private let application: URLOpener
     
     private let enablePopupBridgeAppSwitch: Bool
     private var webAuthenticationSession: WebAuthenticationSession = WebAuthenticationSession()
     private var returnBlock: ((URL) -> Void)? = nil
     private var launchAppReturnObserver: NSObjectProtocol?
-    private static let logDateFormatter = ISO8601DateFormatter()
+
     // MARK: - Initializers
         
     /// Initialize a Popup Bridge.
@@ -37,6 +37,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     ///   appSwitchWhenAvailable which controls non-webview mobile browser app switch.
     public init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, enablePopupBridgeAppSwitch: Bool = false) {
         self.webView = webView
+        self.application = UIApplication.shared
         self.enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch
 
         super.init()
@@ -76,8 +77,8 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// Internal designated init that accepts a URLOpener for testing
     init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, enablePopupBridgeAppSwitch: Bool = false, application: URLOpener) {
         self.webView = webView
-        self.enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch
         self.application = application
+        self.enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch
 
         super.init()
 
@@ -95,8 +96,8 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     }
 
     deinit {
-        if let observer = launchAppReturnObserver {
-            NotificationCenter.default.removeObserver(observer)
+        if let launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(launchAppReturnObserver)
         }
         webView.configuration.userContentController.removeAllScriptMessageHandlers()
     }
@@ -106,9 +107,8 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// Starts listening for the return URL notification posted by the host app's SceneDelegate.
     /// Called only after a successful launchApp; removed after handling.
     private func startObservingLaunchAppReturn() {
-        // Remove any stale observer before adding a new one
-        if let observer = launchAppReturnObserver {
-            NotificationCenter.default.removeObserver(observer)
+        if let launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(launchAppReturnObserver)
         }
 
         launchAppReturnObserver = NotificationCenter.default.addObserver(
@@ -116,23 +116,25 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            guard let self,
-                  let url = notification.userInfo?["url"] as? URL else {
+            guard let self else {
                 return
             }
+
+            guard let url = notification.userInfo?["url"] as? URL else {
+                return
+            }
+
             self.handleLaunchAppReturn(url: url)
         }
     }
 
     /// Parses the return URL and injects `window.popupBridge.onComplete()` into the WebView.
-    /// Venice may return fragment-based data for web_sdk integration:
+    /// The return URL may include fragment-based data:
     ///   merchantapp://popupbridgev1/onApprove#onApprove&PayerID=XXX&token=EC-YYY
-    /// The JS SDK is responsible for normalizing `path`, `queryItems`, and `hash`.
+    /// Popup Bridge JavaScript is responsible for normalizing `path`, `queryItems`, and `hash`.
     private func handleLaunchAppReturn(url: URL) {
-
-        // One-shot: stop observing immediately
-        if let observer = launchAppReturnObserver {
-            NotificationCenter.default.removeObserver(observer)
+        if let launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(launchAppReturnObserver)
             launchAppReturnObserver = nil
         }
 
@@ -221,15 +223,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         )
         
         let isPayPalInstalled = enablePopupBridgeAppSwitch && application.isPayPalAppInstalled()
-        if enablePopupBridgeAppSwitch {
-            Self.analyticsService.sendAnalyticsEvent(
-                isPayPalInstalled ? PopupBridgeAnalytics.paypalInstalled : PopupBridgeAnalytics.paypalNotInstalled,
-                sessionID: sessionID
-            )
-        }
 
         // Read the merchant app's registered URL scheme from Info.plist CFBundleURLSchemes
-        let returnUrlScheme: String? = {
+        let returnURLScheme: String? = {
             guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
                 return nil
             }
@@ -247,7 +243,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             host: hostName,
             isVenmoInstalled: application.isVenmoAppInstalled(),
             isPayPalInstalled: isPayPalInstalled,
-            returnUrlScheme: returnUrlScheme
+            returnURLScheme: returnURLScheme
         ).rawJavascript
         
         let script = WKUserScript(

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -21,8 +21,8 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private var webAuthenticationSession: WebAuthenticationSession = WebAuthenticationSession()
     private var returnBlock: ((URL) -> Void)? = nil
     private var launchAppReturnObserver: NSObjectProtocol?
-    private var pendingLaunchAppResult: String?
-    
+
+    private static let logDateFormatter = ISO8601DateFormatter()
     // MARK: - Initializers
         
     /// Initialize a Popup Bridge.
@@ -105,6 +105,12 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             NotificationCenter.default.removeObserver(observer)
         }
 
+        NSLog(
+            "[tanya] POPPopupBridge.startObservingLaunchAppReturn: sessionID=%@ time=%@",
+            sessionID,
+            Self.logDateFormatter.string(from: Date())
+        )
+
         launchAppReturnObserver = NotificationCenter.default.addObserver(
             forName: Notification.Name("popupBridgeReturnURL"),
             object: nil,
@@ -114,6 +120,12 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                   let url = notification.userInfo?["url"] as? URL else {
                 return
             }
+            NSLog(
+                "[tanya] POPPopupBridge.popupBridgeReturnURL observer fired: sessionID=%@ url=%@ time=%@",
+                self.sessionID,
+                url.absoluteString,
+                Self.logDateFormatter.string(from: Date())
+            )
             self.handleLaunchAppReturn(url: url)
         }
     }
@@ -124,6 +136,13 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// The fragment contains key=value pairs that must be merged into queryItems
     /// since the JS SDK reads result.queryItems (not result.hash).
     private func handleLaunchAppReturn(url: URL) {
+        NSLog(
+            "[tanya] POPPopupBridge.handleLaunchAppReturn ENTER: sessionID=%@ url=%@ time=%@",
+            sessionID,
+            url.absoluteString,
+            Self.logDateFormatter.string(from: Date())
+        )
+
         // One-shot: stop observing immediately
         if let observer = launchAppReturnObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -134,7 +153,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             return
         }
 
-        // Start with query string params (if any)
         var queryItems = urlComponents.queryItems?.reduce(into: [String: String]()) { partialResult, queryItem in
             partialResult[queryItem.name] = queryItem.value
         } ?? [:]
@@ -171,30 +189,26 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         if let payloadData = try? JSONEncoder().encode(payload),
            let payloadString = String(data: payloadData, encoding: .utf8) {
             Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
+            NSLog(
+                "[tanya] POPPopupBridge.handleLaunchAppReturn payload built: sessionID=%@ payload=%@",
+                sessionID,
+                payloadString
+            )
 
-            // Store result so it survives WKWebView content process termination.
-            // Also inject a WKUserScript that will set __pendingResult on the
-            // next page load, allowing the JS SDK to pick it up on re-init.
-            pendingLaunchAppResult = payloadString
-            let pendingJs = """
+            let script = """
                 ;(function() {
-                    if (!window.popupBridge) { window.popupBridge = {}; }
-                    window.popupBridge.__pendingResult = \(payloadString);
+                    if (typeof window.popupBridge !== 'undefined' && typeof window.popupBridge.onComplete === 'function') {
+                        window.popupBridge.onComplete(null, \(payloadString));
+                    } else {
+                        if (!window.popupBridge) { window.popupBridge = {}; }
+                        window.popupBridge.__pendingResult = \(payloadString);
+                    }
                 })();
             """
-            let pendingScript = WKUserScript(
-                source: pendingJs,
-                injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+            NSLog(
+                "[tanya] POPPopupBridge.handleLaunchAppReturn injecting completion JS: sessionID=%@",
+                sessionID
             )
-            webView.configuration.userContentController.addUserScript(pendingScript)
-
-            // Try immediate injection for the case where the page is still alive
-            let script = """
-                if (typeof window.popupBridge !== 'undefined' && typeof window.popupBridge.onComplete === 'function') {
-                    window.popupBridge.onComplete(null, \(payloadString));
-                }
-            """
             injectWebView(webView: webView, withJavaScript: script)
         } else {
             let errorMessage = "Failed to parse query items from return URL."
@@ -309,9 +323,21 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             }
 
             if let launchAppURLString = script.launchApp, let launchAppURL = URL(string: launchAppURLString) {
+                NSLog(
+                    "[tanya] POPPopupBridge.launchApp requested: sessionID=%@ url=%@ time=%@",
+                    sessionID,
+                    launchAppURL.absoluteString,
+                    Self.logDateFormatter.string(from: Date())
+                )
                 Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchStarted, sessionID: sessionID)
                 application.openURL(launchAppURL) { [weak self] success in
                     guard let self else { return }
+                    NSLog(
+                        "[tanya] POPPopupBridge.launchApp completion: sessionID=%@ success=%@ time=%@",
+                        self.sessionID,
+                        success.description,
+                        Self.logDateFormatter.string(from: Date())
+                    )
                     if success {
                         Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchSucceeded, sessionID: self.sessionID)
                         self.startObservingLaunchAppReturn()

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -22,7 +22,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private var webAuthenticationSession: WebAuthenticationSession = WebAuthenticationSession()
     private var returnBlock: ((URL) -> Void)? = nil
     private var launchAppReturnObserver: NSObjectProtocol?
-
     private static let logDateFormatter = ISO8601DateFormatter()
     // MARK: - Initializers
         
@@ -324,7 +323,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                     """
 
                     Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.canceled, sessionID: sessionID)
-
+                    
                     injectWebView(webView: webView, withJavaScript: script)
                     return
                 }

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -16,10 +16,12 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private let hostName = "popupbridgev1"
     private let sessionID = UUID().uuidString.replacingOccurrences(of: "-", with: "")
     private let webView: WKWebView
-    private let application: URLOpener = UIApplication.shared
+    private var application: URLOpener = UIApplication.shared
     
     private var webAuthenticationSession: WebAuthenticationSession = WebAuthenticationSession()
     private var returnBlock: ((URL) -> Void)? = nil
+    private var launchAppReturnObserver: NSObjectProtocol?
+    private var pendingLaunchAppResult: String?
     
     // MARK: - Initializers
         
@@ -31,12 +33,12 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     ///   Defaults to `true`.
     public init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true) {
         self.webView = webView
-        
+
         super.init()
 
         configureWebView()
         webAuthenticationSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
-                
+
         returnBlock = { [weak self] url in
             guard let script = self?.constructJavaScriptCompletionResult(returnURL: url) else {
                 return
@@ -55,15 +57,158 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         self.init(webView: webView)
         self.webAuthenticationSession = webAuthenticationSession
     }
-    
+
+    /// Exposed for testing
+    convenience init(
+        webView: WKWebView,
+        webAuthenticationSession: WebAuthenticationSession,
+        application: URLOpener
+    ) {
+        self.init(webView: webView, application: application)
+        self.webAuthenticationSession = webAuthenticationSession
+    }
+
+    /// Internal designated init that accepts a URLOpener for testing
+    init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, application: URLOpener) {
+        self.webView = webView
+        self.application = application
+
+        super.init()
+
+        configureWebView()
+        webAuthenticationSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+
+        returnBlock = { [weak self] url in
+            guard let script = self?.constructJavaScriptCompletionResult(returnURL: url) else {
+                return
+            }
+
+            self?.injectWebView(webView: webView, withJavaScript: script)
+            return
+        }
+    }
+
     deinit {
+        if let observer = launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
         webView.configuration.userContentController.removeAllScriptMessageHandlers()
     }
     
+    // MARK: - Launch App Return Handling
+
+    /// Starts listening for the return URL notification posted by the host app's SceneDelegate.
+    /// Called only after a successful launchApp; removed after handling.
+    private func startObservingLaunchAppReturn() {
+        // Remove any stale observer before adding a new one
+        if let observer = launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+
+        launchAppReturnObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("popupBridgeReturnURL"),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let url = notification.userInfo?["url"] as? URL else {
+                return
+            }
+            self.handleLaunchAppReturn(url: url)
+        }
+    }
+
+    /// Parses the return URL and injects `window.popupBridge.onComplete()` into the WebView.
+    /// Venice uses fragment-based return for web_sdk integration:
+    ///   merchantapp://popupbridgev1/onApprove#onApprove&PayerID=XXX&token=EC-YYY
+    /// The fragment contains key=value pairs that must be merged into queryItems
+    /// since the JS SDK reads result.queryItems (not result.hash).
+    private func handleLaunchAppReturn(url: URL) {
+        // One-shot: stop observing immediately
+        if let observer = launchAppReturnObserver {
+            NotificationCenter.default.removeObserver(observer)
+            launchAppReturnObserver = nil
+        }
+
+        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return
+        }
+
+        // Start with query string params (if any)
+        var queryItems = urlComponents.queryItems?.reduce(into: [String: String]()) { partialResult, queryItem in
+            partialResult[queryItem.name] = queryItem.value
+        } ?? [:]
+
+        // Parse fragment params (e.g. "onApprove&PayerID=XXX&token=EC-YYY") and merge
+        if let fragment = urlComponents.fragment {
+            let fragmentComponents = fragment.components(separatedBy: "&")
+            for component in fragmentComponents {
+                let parts = component.components(separatedBy: "=")
+                if parts.count == 2 {
+                    queryItems[parts[0]] = parts[1].removingPercentEncoding ?? parts[1]
+                }
+            }
+        }
+
+        // Map the path to the opType expected by the JS SDK's popup-bridge payment flow.
+        // Venice returns /onApprove or /onCancel in the path; the JS SDK expects
+        // opType "payment" or "cancel" respectively.
+        if queryItems["opType"] == nil {
+            let path = urlComponents.path.lowercased()
+            if path.contains("onapprove") {
+                queryItems["opType"] = "payment"
+            } else if path.contains("oncancel") {
+                queryItems["opType"] = "cancel"
+            }
+        }
+
+        let payload = URLDetailsPayload(
+            path: urlComponents.path,
+            queryItems: queryItems,
+            hash: urlComponents.fragment
+        )
+
+        if let payloadData = try? JSONEncoder().encode(payload),
+           let payloadString = String(data: payloadData, encoding: .utf8) {
+            Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
+
+            // Store result so it survives WKWebView content process termination.
+            // Also inject a WKUserScript that will set __pendingResult on the
+            // next page load, allowing the JS SDK to pick it up on re-init.
+            pendingLaunchAppResult = payloadString
+            let pendingJs = """
+                ;(function() {
+                    if (!window.popupBridge) { window.popupBridge = {}; }
+                    window.popupBridge.__pendingResult = \(payloadString);
+                })();
+            """
+            let pendingScript = WKUserScript(
+                source: pendingJs,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: false
+            )
+            webView.configuration.userContentController.addUserScript(pendingScript)
+
+            // Try immediate injection for the case where the page is still alive
+            let script = """
+                if (typeof window.popupBridge !== 'undefined' && typeof window.popupBridge.onComplete === 'function') {
+                    window.popupBridge.onComplete(null, \(payloadString));
+                }
+            """
+            injectWebView(webView: webView, withJavaScript: script)
+        } else {
+            let errorMessage = "Failed to parse query items from return URL."
+            let errorResponse = "new Error(\"\(errorMessage)\")"
+            Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.failed, sessionID: sessionID)
+            let script = "window.popupBridge.onComplete(\(errorResponse), null);"
+            injectWebView(webView: webView, withJavaScript: script)
+        }
+    }
+
     // MARK: - Internal Methods
 
     /// Exposed for testing
-    /// 
+    ///
     /// Constructs custom JavaScript to be injected into the merchant's WKWebView, based on redirectURL details from the SFSafariViewController pop-up result.
     /// - Parameter url: returnURL from the result of the ASWebAuthenticationSession.
     /// - Returns: JavaScript formatted completion.
@@ -106,11 +251,18 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             name: messageHandlerName
         )
         
+        let isPayPalInstalled = application.isPayPalAppInstalled()
+        Self.analyticsService.sendAnalyticsEvent(
+            isPayPalInstalled ? PopupBridgeAnalytics.paypalInstalled : PopupBridgeAnalytics.paypalNotInstalled,
+            sessionID: sessionID
+        )
+
         let javascript = PopupBridgeUserScript(
             scheme: PopupBridgeConstants.callbackURLScheme,
             scriptMessageHandlerName: messageHandlerName,
             host: hostName,
-            isVenmoInstalled: application.isVenmoAppInstalled()
+            isVenmoInstalled: application.isVenmoAppInstalled(),
+            isPayPalInstalled: isPayPalInstalled
         ).rawJavascript
         
         let script = WKUserScript(
@@ -141,8 +293,35 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                   let script = try? JSONDecoder().decode(WebViewMessage.self, from: jsonData) else {
                 return
             }
-            
-            if let urlString = script.url, let url = URL(string: urlString) {
+
+            if let launchAppURLString = script.launchApp, let launchAppURL = URL(string: launchAppURLString) {
+                Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchStarted, sessionID: sessionID)
+                application.openURL(launchAppURL) { [weak self] success in
+                    guard let self else { return }
+                    if success {
+                        Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchSucceeded, sessionID: self.sessionID)
+                        self.startObservingLaunchAppReturn()
+                    } else {
+                        Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchFailed, sessionID: self.sessionID)
+                        self.webAuthenticationSession.start(url: launchAppURL, context: self) { url, _ in
+                            if let url, let returnBlock = self.returnBlock {
+                                self.returnedWithURL = true
+                                returnBlock(url)
+                            }
+                        } sessionDidCancel: {
+                            let cancelScript = """
+                                if (typeof window.popupBridge.onCancel === 'function') {\
+                                    window.popupBridge.onCancel();\
+                                } else {\
+                                    window.popupBridge.onComplete(null, null);\
+                                }
+                            """
+                            Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.canceled, sessionID: self.sessionID)
+                            self.injectWebView(webView: self.webView, withJavaScript: cancelScript)
+                        }
+                    }
+                }
+            } else if let urlString = script.url, let url = URL(string: urlString) {
                 webAuthenticationSession.start(url: url, context: self) { url, _ in
                     if let url, let returnBlock = self.returnBlock {
                         self.returnedWithURL = true
@@ -157,9 +336,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                             window.popupBridge.onComplete(null, null);\
                         }
                     """
-                    
+
                     Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.canceled, sessionID: sessionID)
-                    
+
                     injectWebView(webView: webView, withJavaScript: script)
                     return
                 }

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -257,12 +257,26 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             sessionID: sessionID
         )
 
+        // Read the merchant app's registered URL scheme from Info.plist CFBundleURLSchemes
+        let returnUrlScheme: String? = {
+            guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
+                return nil
+            }
+            for urlType in urlTypes {
+                if let schemes = urlType["CFBundleURLSchemes"] as? [String], let scheme = schemes.first {
+                    return scheme
+                }
+            }
+            return nil
+        }()
+
         let javascript = PopupBridgeUserScript(
             scheme: PopupBridgeConstants.callbackURLScheme,
             scriptMessageHandlerName: messageHandlerName,
             host: hostName,
             isVenmoInstalled: application.isVenmoAppInstalled(),
-            isPayPalInstalled: isPayPalInstalled
+            isPayPalInstalled: isPayPalInstalled,
+            returnUrlScheme: returnUrlScheme
         ).rawJavascript
         
         let script = WKUserScript(

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -177,7 +177,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     // MARK: - Internal Methods
 
     /// Exposed for testing
-    ///
+    /// 
     /// Constructs custom JavaScript to be injected into the merchant's WKWebView, based on redirectURL details from the SFSafariViewController pop-up result.
     /// - Parameter url: returnURL from the result of the ASWebAuthenticationSession.
     /// - Returns: JavaScript formatted completion.
@@ -323,7 +323,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                     """
 
                     Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.canceled, sessionID: sessionID)
-                    
+
                     injectWebView(webView: webView, withJavaScript: script)
                     return
                 }

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -153,7 +153,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         )
 
         if let payloadData = try? JSONEncoder().encode(payload),
-           let payloadString = String(data: payloadData, encoding: .utf8) {
+            let payloadString = String(data: payloadData, encoding: .utf8) {
             Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
 
             let script = """
@@ -202,7 +202,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         )
 
         if let payloadData = try? JSONEncoder().encode(payload),
-           let payload = String(data: payloadData, encoding: .utf8) {
+            let payload = String(data: payloadData, encoding: .utf8) {
             Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
             return "window.popupBridge.onComplete(null, \(payload));"
         } else {
@@ -279,6 +279,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                 Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchStarted, sessionID: sessionID)
                 application.openURL(launchAppURL) { [weak self] success in
                     guard let self else { return }
+                    
                     if success {
                         Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchSucceeded, sessionID: self.sessionID)
                         self.startObservingLaunchAppReturn()

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -18,6 +18,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private let webView: WKWebView
     private var application: URLOpener = UIApplication.shared
     
+    private let enablePopupBridgeAppSwitch: Bool
     private var webAuthenticationSession: WebAuthenticationSession = WebAuthenticationSession()
     private var returnBlock: ((URL) -> Void)? = nil
     private var launchAppReturnObserver: NSObjectProtocol?
@@ -29,10 +30,15 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     /// - Parameters:
     ///   - webView: The web view to add a script message handler to. Do not change the web view's configuration or user content controller after initializing Popup Bridge.
     ///   - prefersEphemeralWebBrowserSession: A Boolean that, when true, requests that the browser does not share cookies
-    ///   or other browsing data between the authenthication session and the user’s normal browser session.
+    ///   or other browsing data between the authenthication session and the user's normal browser session.
     ///   Defaults to `true`.
-    public init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true) {
+    ///   - enablePopupBridgeAppSwitch: When true, allows the SDK to launch the native PayPal app for checkout
+    ///   instead of opening a browser. Defaults to false for backward compatibility.
+    ///   This is specific to the popup bridge flow and is separate from the JS SDK's
+    ///   appSwitchWhenAvailable which controls non-webview mobile browser app switch.
+    public init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, enablePopupBridgeAppSwitch: Bool = false) {
         self.webView = webView
+        self.enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch
 
         super.init()
 
@@ -69,8 +75,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     }
 
     /// Internal designated init that accepts a URLOpener for testing
-    init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, application: URLOpener) {
+    init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, enablePopupBridgeAppSwitch: Bool = false, application: URLOpener) {
         self.webView = webView
+        self.enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch
         self.application = application
 
         super.init()
@@ -241,11 +248,13 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             name: messageHandlerName
         )
         
-        let isPayPalInstalled = application.isPayPalAppInstalled()
-        Self.analyticsService.sendAnalyticsEvent(
-            isPayPalInstalled ? PopupBridgeAnalytics.paypalInstalled : PopupBridgeAnalytics.paypalNotInstalled,
-            sessionID: sessionID
-        )
+        let isPayPalInstalled = enablePopupBridgeAppSwitch && application.isPayPalAppInstalled()
+        if enablePopupBridgeAppSwitch {
+            Self.analyticsService.sendAnalyticsEvent(
+                isPayPalInstalled ? PopupBridgeAnalytics.paypalInstalled : PopupBridgeAnalytics.paypalNotInstalled,
+                sessionID: sessionID
+            )
+        }
 
         // Read the merchant app's registered URL scheme from Info.plist CFBundleURLSchemes
         let returnUrlScheme: String? = {

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -112,12 +112,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             NotificationCenter.default.removeObserver(observer)
         }
 
-        NSLog(
-            "[tanya] POPPopupBridge.startObservingLaunchAppReturn: sessionID=%@ time=%@",
-            sessionID,
-            Self.logDateFormatter.string(from: Date())
-        )
-
         launchAppReturnObserver = NotificationCenter.default.addObserver(
             forName: Notification.Name("popupBridgeReturnURL"),
             object: nil,
@@ -127,12 +121,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                   let url = notification.userInfo?["url"] as? URL else {
                 return
             }
-            NSLog(
-                "[tanya] POPPopupBridge.popupBridgeReturnURL observer fired: sessionID=%@ url=%@ time=%@",
-                self.sessionID,
-                url.absoluteString,
-                Self.logDateFormatter.string(from: Date())
-            )
             self.handleLaunchAppReturn(url: url)
         }
     }
@@ -142,12 +130,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     ///   merchantapp://popupbridgev1/onApprove#onApprove&PayerID=XXX&token=EC-YYY
     /// The JS SDK is responsible for normalizing `path`, `queryItems`, and `hash`.
     private func handleLaunchAppReturn(url: URL) {
-        NSLog(
-            "[tanya] POPPopupBridge.handleLaunchAppReturn ENTER: sessionID=%@ url=%@ time=%@",
-            sessionID,
-            url.absoluteString,
-            Self.logDateFormatter.string(from: Date())
-        )
 
         // One-shot: stop observing immediately
         if let observer = launchAppReturnObserver {
@@ -172,11 +154,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         if let payloadData = try? JSONEncoder().encode(payload),
            let payloadString = String(data: payloadData, encoding: .utf8) {
             Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
-            NSLog(
-                "[tanya] POPPopupBridge.handleLaunchAppReturn payload built: sessionID=%@ payload=%@",
-                sessionID,
-                payloadString
-            )
 
             let script = """
                 ;(function() {
@@ -188,10 +165,6 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
                     }
                 })();
             """
-            NSLog(
-                "[tanya] POPPopupBridge.handleLaunchAppReturn injecting completion JS: sessionID=%@",
-                sessionID
-            )
             injectWebView(webView: webView, withJavaScript: script)
         } else {
             let errorMessage = "Failed to parse query items from return URL."
@@ -308,21 +281,9 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             }
 
             if let launchAppURLString = script.launchApp, let launchAppURL = URL(string: launchAppURLString) {
-                NSLog(
-                    "[tanya] POPPopupBridge.launchApp requested: sessionID=%@ url=%@ time=%@",
-                    sessionID,
-                    launchAppURL.absoluteString,
-                    Self.logDateFormatter.string(from: Date())
-                )
                 Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchStarted, sessionID: sessionID)
                 application.openURL(launchAppURL) { [weak self] success in
                     guard let self else { return }
-                    NSLog(
-                        "[tanya] POPPopupBridge.launchApp completion: sessionID=%@ success=%@ time=%@",
-                        self.sessionID,
-                        success.description,
-                        Self.logDateFormatter.string(from: Date())
-                    )
                     if success {
                         Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.appLaunchSucceeded, sessionID: self.sessionID)
                         self.startObservingLaunchAppReturn()

--- a/Sources/PopupBridge/POPPopupBridge.swift
+++ b/Sources/PopupBridge/POPPopupBridge.swift
@@ -74,6 +74,17 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
         self.webAuthenticationSession = webAuthenticationSession
     }
 
+    /// Exposed for testing
+    convenience init(
+        webView: WKWebView,
+        webAuthenticationSession: WebAuthenticationSession,
+        enablePopupBridgeAppSwitch: Bool = false,
+        application: URLOpener
+    ) {
+        self.init(webView: webView, enablePopupBridgeAppSwitch: enablePopupBridgeAppSwitch, application: application)
+        self.webAuthenticationSession = webAuthenticationSession
+    }
+
     /// Internal designated init that accepts a URLOpener for testing
     init(webView: WKWebView, prefersEphemeralWebBrowserSession: Bool = true, enablePopupBridgeAppSwitch: Bool = false, application: URLOpener) {
         self.webView = webView
@@ -135,7 +146,7 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
     private func handleLaunchAppReturn(url: URL) {
         if let launchAppReturnObserver {
             NotificationCenter.default.removeObserver(launchAppReturnObserver)
-            launchAppReturnObserver = nil
+            self.launchAppReturnObserver = nil
         }
 
         guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
@@ -156,6 +167,10 @@ public class POPPopupBridge: NSObject, WKScriptMessageHandler {
             let payloadString = String(data: payloadData, encoding: .utf8) {
             Self.analyticsService.sendAnalyticsEvent(PopupBridgeAnalytics.succeeded, sessionID: sessionID)
 
+            // The leading semicolon is a defensive IIFE guard: if the previous JS statement
+            // on the page was left without a semicolon, concatenating a bare `(function(){…})()`
+            // would be parsed as a function-call on that expression and throw. The `;` ensures
+            // a clean statement boundary regardless of surrounding page JS.
             let script = """
                 ;(function() {
                     if (typeof window.popupBridge !== 'undefined' && typeof window.popupBridge.onComplete === 'function') {

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -7,16 +7,29 @@ struct PopupBridgeUserScript {
     let host: String
     let isVenmoInstalled: Bool
     let isPayPalInstalled: Bool
-    
+    let returnUrlScheme: String?
+
     var rawJavascript: String {
-        """
+        let deepLinkJs: String
+        if let returnUrlScheme {
+            deepLinkJs = """
+
+                        window.popupBridge.getDeepLinkReturnUrlPrefix = function getDeepLinkReturnUrlPrefix() {
+                            return '\(returnUrlScheme)://\(host)/';
+                        };
+            """
+        } else {
+            deepLinkJs = ""
+        }
+
+        return """
         ;(function () {
             if (!window.popupBridge) { window.popupBridge = {}; };
 
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {
                 return '\(scheme)://\(host)/';
-            };
-            
+            };\(deepLinkJs)
+
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
 
             window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -6,6 +6,7 @@ struct PopupBridgeUserScript {
     let scriptMessageHandlerName: String
     let host: String
     let isVenmoInstalled: Bool
+    let isPayPalInstalled: Bool
     
     var rawJavascript: String {
         """
@@ -17,7 +18,16 @@ struct PopupBridgeUserScript {
             };
             
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
-            
+
+            window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);
+
+            window.popupBridge.launchApp = function launchApp(url) {
+                window.webkit.messageHandlers.\(scriptMessageHandlerName)
+                    .postMessage({
+                    launchApp: url
+                });
+            };
+
             window.popupBridge.open = function open(url) {
                 window.webkit.messageHandlers.\(scriptMessageHandlerName)
                     .postMessage({
@@ -34,7 +44,7 @@ struct PopupBridgeUserScript {
                     }
                 });
             };
-        
+
             return 0;
         })();
         """

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -10,12 +10,12 @@ struct PopupBridgeUserScript {
 
     var rawJavascript: String {
         let returnURLPrefix = "\(scheme)://\(host)/"
-        let deepLinkJs: String
+        let deepLinkJS: String
         let deepLinkProperty: String
 
         if let returnURLScheme {
             let deepLinkReturnURLPrefix = "\(returnURLScheme)://\(host)/"
-            deepLinkJs = """
+            deepLinkJS = """
 
                         window.popupBridge.getDeepLinkReturnUrlPrefix = function getDeepLinkReturnUrlPrefix() {
                             return '\(deepLinkReturnURLPrefix)';
@@ -26,7 +26,7 @@ struct PopupBridgeUserScript {
             window.popupBridge.deepLinkReturnUrlPrefix = '\(deepLinkReturnURLPrefix)';
             """
         } else {
-            deepLinkJs = ""
+            deepLinkJS = ""
             deepLinkProperty = ""
         }
 
@@ -36,7 +36,7 @@ struct PopupBridgeUserScript {
 
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {
                 return '\(returnURLPrefix)';
-            };\(deepLinkJs)\(deepLinkProperty)
+            };\(deepLinkJS)\(deepLinkProperty)
 
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
             window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct PopupBridgeUserScript {
-    
+
     let scheme: String
     let scriptMessageHandlerName: String
     let host: String
@@ -10,16 +10,25 @@ struct PopupBridgeUserScript {
     let returnUrlScheme: String?
 
     var rawJavascript: String {
+        let returnUrlPrefix = "\(scheme)://\(host)/"
         let deepLinkJs: String
+        let deepLinkProperty: String
+
         if let returnUrlScheme {
+            let deepLinkReturnUrlPrefix = "\(returnUrlScheme)://\(host)/"
             deepLinkJs = """
 
                         window.popupBridge.getDeepLinkReturnUrlPrefix = function getDeepLinkReturnUrlPrefix() {
-                            return '\(returnUrlScheme)://\(host)/';
+                            return '\(deepLinkReturnUrlPrefix)';
                         };
+            """
+            deepLinkProperty = """
+
+            window.popupBridge.deepLinkReturnUrlPrefix = '\(deepLinkReturnUrlPrefix)';
             """
         } else {
             deepLinkJs = ""
+            deepLinkProperty = ""
         }
 
         return """
@@ -27,30 +36,26 @@ struct PopupBridgeUserScript {
             if (!window.popupBridge) { window.popupBridge = {}; };
 
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {
-                return '\(scheme)://\(host)/';
-            };\(deepLinkJs)
+                return '\(returnUrlPrefix)';
+            };\(deepLinkJs)\(deepLinkProperty)
 
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
-
             window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);
 
             window.popupBridge.launchApp = function launchApp(url) {
-                window.webkit.messageHandlers.\(scriptMessageHandlerName)
-                    .postMessage({
+                window.webkit.messageHandlers.\(scriptMessageHandlerName).postMessage({
                     launchApp: url
                 });
             };
 
             window.popupBridge.open = function open(url) {
-                window.webkit.messageHandlers.\(scriptMessageHandlerName)
-                    .postMessage({
+                window.webkit.messageHandlers.\(scriptMessageHandlerName).postMessage({
                     url: url
                 });
             };
-        
+
             window.popupBridge.sendMessage = function sendMessage(message, data) {
-                window.webkit.messageHandlers.\(scriptMessageHandlerName)
-                    .postMessage({
+                window.webkit.messageHandlers.\(scriptMessageHandlerName).postMessage({
                     message: {
                         name: message,
                         data: data

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -6,28 +6,28 @@ struct PopupBridgeUserScript {
     let host: String
     let isVenmoInstalled: Bool
     let isPayPalInstalled: Bool
-    let returnUrlScheme: String?
+    let returnURLScheme: String?
 
     var rawJavascript: String {
-        let returnUrlPrefix = "\(scheme)://\(host)/"
-        let deepLinkJs: String
-        let deepLinkProperty: String
+        let returnURLPrefix = "\(scheme)://\(host)/"
+        let deepLinkAccessorJS: String
+        let deepLinkPropertyAssignment: String
 
-        if let returnUrlScheme {
-            let deepLinkReturnUrlPrefix = "\(returnUrlScheme)://\(host)/"
-            deepLinkJs = """
+        if let returnURLScheme {
+            let deepLinkReturnURLPrefix = "\(returnURLScheme)://\(host)/"
+            deepLinkAccessorJS = """
 
                         window.popupBridge.getDeepLinkReturnUrlPrefix = function getDeepLinkReturnUrlPrefix() {
-                            return '\(deepLinkReturnUrlPrefix)';
+                            return '\(deepLinkReturnURLPrefix)';
                         };
             """
-            deepLinkProperty = """
+            deepLinkPropertyAssignment = """
 
-            window.popupBridge.deepLinkReturnUrlPrefix = '\(deepLinkReturnUrlPrefix)';
+            window.popupBridge.deepLinkReturnUrlPrefix = '\(deepLinkReturnURLPrefix)';
             """
         } else {
-            deepLinkJs = ""
-            deepLinkProperty = ""
+            deepLinkAccessorJS = ""
+            deepLinkPropertyAssignment = ""
         }
 
         return """
@@ -35,8 +35,8 @@ struct PopupBridgeUserScript {
             if (!window.popupBridge) { window.popupBridge = {}; };
 
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {
-                return '\(returnUrlPrefix)';
-            };\(deepLinkJs)\(deepLinkProperty)
+                return '\(returnURLPrefix)';
+            };\(deepLinkAccessorJS)\(deepLinkPropertyAssignment)
 
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
             window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -10,24 +10,24 @@ struct PopupBridgeUserScript {
 
     var rawJavascript: String {
         let returnURLPrefix = "\(scheme)://\(host)/"
-        let deepLinkAccessorJS: String
-        let deepLinkPropertyAssignment: String
+        let deepLinkJs: String
+        let deepLinkProperty: String
 
         if let returnURLScheme {
             let deepLinkReturnURLPrefix = "\(returnURLScheme)://\(host)/"
-            deepLinkAccessorJS = """
+            deepLinkJs = """
 
                         window.popupBridge.getDeepLinkReturnUrlPrefix = function getDeepLinkReturnUrlPrefix() {
                             return '\(deepLinkReturnURLPrefix)';
                         };
             """
-            deepLinkPropertyAssignment = """
+            deepLinkProperty = """
 
             window.popupBridge.deepLinkReturnUrlPrefix = '\(deepLinkReturnURLPrefix)';
             """
         } else {
-            deepLinkAccessorJS = ""
-            deepLinkPropertyAssignment = ""
+            deepLinkJs = ""
+            deepLinkProperty = ""
         }
 
         return """
@@ -36,7 +36,7 @@ struct PopupBridgeUserScript {
 
             window.popupBridge.getReturnUrlPrefix = function getReturnUrlPrefix() {
                 return '\(returnURLPrefix)';
-            };\(deepLinkAccessorJS)\(deepLinkPropertyAssignment)
+            };\(deepLinkJs)\(deepLinkProperty)
 
             window.popupBridge.isVenmoInstalled = \(isVenmoInstalled);
             window.popupBridge.isPayPalInstalled = \(isPayPalInstalled);

--- a/Sources/PopupBridge/PopupBridgeUserScript.swift
+++ b/Sources/PopupBridge/PopupBridgeUserScript.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct PopupBridgeUserScript {
-
     let scheme: String
     let scriptMessageHandlerName: String
     let host: String
@@ -62,7 +61,7 @@ struct PopupBridgeUserScript {
                     }
                 });
             };
-
+            
             return 0;
         })();
         """

--- a/Sources/PopupBridge/UIApplication+URLOpener.swift
+++ b/Sources/PopupBridge/UIApplication+URLOpener.swift
@@ -1,14 +1,12 @@
 import UIKit
 
 protocol URLOpener {
-
     func isVenmoAppInstalled() -> Bool
     func isPayPalAppInstalled() -> Bool
     func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void)
 }
 
 extension UIApplication: URLOpener {
-
     /// Indicates whether the Venmo App is installed.
     func isVenmoAppInstalled() -> Bool {
         guard let venmoURL = URL(string: "com.venmo.touch.v2://") else {

--- a/Sources/PopupBridge/UIApplication+URLOpener.swift
+++ b/Sources/PopupBridge/UIApplication+URLOpener.swift
@@ -1,17 +1,31 @@
 import UIKit
 
 protocol URLOpener {
-    
+
     func isVenmoAppInstalled() -> Bool
+    func isPayPalAppInstalled() -> Bool
+    func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void)
 }
 
 extension UIApplication: URLOpener {
-    
+
     /// Indicates whether the Venmo App is installed.
     func isVenmoAppInstalled() -> Bool {
         guard let venmoURL = URL(string: "com.venmo.touch.v2://") else {
             return false
         }
         return canOpenURL(venmoURL)
+    }
+
+    /// Indicates whether the PayPal App is installed.
+    func isPayPalAppInstalled() -> Bool {
+        guard let paypalURL = URL(string: "paypal-app-switch-checkout://") else {
+            return false
+        }
+        return canOpenURL(paypalURL)
+    }
+
+    func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void) {
+        open(url, options: [:], completionHandler: completionHandler)
     }
 }

--- a/Sources/PopupBridge/UIApplication+URLOpener.swift
+++ b/Sources/PopupBridge/UIApplication+URLOpener.swift
@@ -17,10 +17,10 @@ extension UIApplication: URLOpener {
 
     /// Indicates whether the PayPal App is installed.
     func isPayPalAppInstalled() -> Bool {
-        guard let paypalURL = URL(string: "paypal-app-switch-checkout://") else {
+        guard let payPalURL = URL(string: "paypal://") else {
             return false
         }
-        return canOpenURL(paypalURL)
+        return canOpenURL(payPalURL)
     }
 
     func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void) {

--- a/Sources/PopupBridge/WebViewMessage.swift
+++ b/Sources/PopupBridge/WebViewMessage.swift
@@ -1,8 +1,9 @@
 /// A model type to represent details in the [`WKScriptMessage.body`](https://developer.apple.com/documentation/webkit/wkscriptmessage/1417901-body), sent by JavaScript code from a webpage.
 struct WebViewMessage: Codable {
-    
+
     let url: String?
     let message: MessageDetails?
+    let launchApp: String?
 }
 
 struct MessageDetails: Codable {

--- a/Sources/PopupBridge/WebViewMessage.swift
+++ b/Sources/PopupBridge/WebViewMessage.swift
@@ -1,6 +1,5 @@
 /// A model type to represent details in the [`WKScriptMessage.body`](https://developer.apple.com/documentation/webkit/wkscriptmessage/1417901-body), sent by JavaScript code from a webpage.
 struct WebViewMessage: Codable {
-
     let url: String?
     let message: MessageDetails?
     let launchApp: String?

--- a/UnitTests/MockAnalyticsService.swift
+++ b/UnitTests/MockAnalyticsService.swift
@@ -6,10 +6,12 @@ class MockAnalyticsService: AnalyticsServiceable {
     var lastEventName: String?
     var lastSessionID: String?
     var eventCount = 0
+    var allEventNames: [String] = []
 
     func sendAnalyticsEvent(_ eventName: String, sessionID: String) {
         lastEventName = eventName
         lastSessionID = sessionID
         eventCount += 1
+        allEventNames.append(eventName)
     }
 }

--- a/UnitTests/MockAnalyticsService.swift
+++ b/UnitTests/MockAnalyticsService.swift
@@ -6,12 +6,12 @@ class MockAnalyticsService: AnalyticsServiceable {
     var lastEventName: String?
     var lastSessionID: String?
     var eventCount = 0
-    var allEventNames: [String] = []
+    var sentEventNames: [String] = []
 
     func sendAnalyticsEvent(_ eventName: String, sessionID: String) {
         lastEventName = eventName
         lastSessionID = sessionID
         eventCount += 1
-        allEventNames.append(eventName)
+        sentEventNames.append(eventName)
     }
 }

--- a/UnitTests/MockURLOpener.swift
+++ b/UnitTests/MockURLOpener.swift
@@ -4,7 +4,7 @@ import Foundation
 class MockURLOpener: URLOpener {
 
     var venmoInstalled = false
-    var paypalInstalled = false
+    var payPalInstalled = false
     var openURLSuccess = true
     var lastOpenedURL: URL?
 
@@ -13,7 +13,7 @@ class MockURLOpener: URLOpener {
     }
 
     func isPayPalAppInstalled() -> Bool {
-        paypalInstalled
+        payPalInstalled
     }
 
     func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void) {

--- a/UnitTests/MockURLOpener.swift
+++ b/UnitTests/MockURLOpener.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import PopupBridge
+
+class MockURLOpener: URLOpener {
+
+    var venmoInstalled = false
+    var paypalInstalled = false
+    var openURLSuccess = true
+    var lastOpenedURL: URL?
+
+    func isVenmoAppInstalled() -> Bool {
+        venmoInstalled
+    }
+
+    func isPayPalAppInstalled() -> Bool {
+        paypalInstalled
+    }
+
+    func openURL(_ url: URL, completionHandler: @escaping (Bool) -> Void) {
+        lastOpenedURL = url
+        completionHandler(openURLSuccess)
+    }
+}

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -373,4 +373,183 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         ))
         webView.load(URLRequest(url: URL(string: "some-popup-bridge-example")!))
     }
+
+    // MARK: - isPayPalInstalled Tests
+
+    func testUserScript_whenPayPalInstalled_containsIsPayPalInstalledTrue() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.paypalInstalled = true
+
+        let webView = WKWebView()
+        let _ = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let userScript = webView.configuration.userContentController.userScripts[0]
+        XCTAssertTrue(userScript.source.contains("window.popupBridge.isPayPalInstalled = true"))
+    }
+
+    func testUserScript_whenPayPalNotInstalled_containsIsPayPalInstalledFalse() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.paypalInstalled = false
+
+        let webView = WKWebView()
+        let _ = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let userScript = webView.configuration.userContentController.userScripts[0]
+        XCTAssertTrue(userScript.source.contains("window.popupBridge.isPayPalInstalled = false"))
+    }
+
+    func testUserScript_containsLaunchAppFunction() {
+        let mockURLOpener = MockURLOpener()
+        let webView = WKWebView()
+        let _ = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let userScript = webView.configuration.userContentController.userScripts[0]
+        XCTAssertTrue(userScript.source.contains("window.popupBridge.launchApp = function launchApp(url)"))
+    }
+
+    // MARK: - launchApp Message Handling Tests
+
+    func testReceiveScriptMessage_whenLaunchAppMessage_opensURL() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.openURLSuccess = true
+
+        let configuration = WKWebViewConfiguration()
+        let mockUserContentController = MockUserContentController()
+        configuration.userContentController = mockUserContentController
+
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let pub = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let stubMessage = MockScriptMessage()
+        stubMessage.body = ["launchApp": "https://example.com/checkout"]
+        stubMessage.name = scriptMessageHandlerName
+
+        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
+
+        XCTAssertEqual(mockURLOpener.lastOpenedURL?.absoluteString, "https://example.com/checkout")
+    }
+
+    func testReceiveScriptMessage_whenLaunchAppSucceeds_sendsSucceededAnalytics() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.openURLSuccess = true
+
+        let configuration = WKWebViewConfiguration()
+        let mockUserContentController = MockUserContentController()
+        configuration.userContentController = mockUserContentController
+
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let pub = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let stubMessage = MockScriptMessage()
+        stubMessage.body = ["launchApp": "https://example.com/checkout"]
+        stubMessage.name = scriptMessageHandlerName
+
+        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
+
+        XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.appLaunchSucceeded)
+    }
+
+    func testReceiveScriptMessage_whenLaunchAppFails_fallsBackToWebAuthenticationSession() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.openURLSuccess = false
+
+        let configuration = WKWebViewConfiguration()
+        let mockUserContentController = MockUserContentController()
+        configuration.userContentController = mockUserContentController
+
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
+        mockWebAuthenticationSession.cannedResponseURL = URL(string: "sdk.ios.popup-bridge://popupbridgev1/return?foo=bar")
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let pub = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let stubMessage = MockScriptMessage()
+        stubMessage.body = ["launchApp": "https://example.com/checkout"]
+        stubMessage.name = scriptMessageHandlerName
+
+        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
+
+        XCTAssertTrue(pub.returnedWithURL)
+        XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.appLaunchFailed)
+    }
+
+    // MARK: - App Detection Analytics Tests
+
+    func testInit_whenPayPalInstalled_sendsPayPalInstalledAnalytics() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.paypalInstalled = true
+
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let _ = POPPopupBridge(
+            webView: WKWebView(),
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.paypalInstalled))
+    }
+
+    func testInit_whenPayPalNotInstalled_sendsPayPalNotInstalledAnalytics() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.paypalInstalled = false
+
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let _ = POPPopupBridge(
+            webView: WKWebView(),
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.paypalNotInstalled))
+    }
+
+    func testReceiveScriptMessage_whenLaunchApp_sendsAppLaunchStartedAnalytics() {
+        let mockURLOpener = MockURLOpener()
+        mockURLOpener.openURLSuccess = true
+
+        let configuration = WKWebViewConfiguration()
+        let mockUserContentController = MockUserContentController()
+        configuration.userContentController = mockUserContentController
+
+        let webView = WKWebView(frame: CGRect(), configuration: configuration)
+        POPPopupBridge.analyticsService = mockAnalyticsService
+        let pub = POPPopupBridge(
+            webView: webView,
+            webAuthenticationSession: mockWebAuthenticationSession,
+            application: mockURLOpener
+        )
+
+        let stubMessage = MockScriptMessage()
+        stubMessage.body = ["launchApp": "https://example.com/checkout"]
+        stubMessage.name = scriptMessageHandlerName
+
+        pub.userContentController(WKUserContentController(), didReceive: stubMessage)
+
+        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.appLaunchStarted))
+    }
 }

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -378,12 +378,13 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
 
     func testUserScript_whenPayPalInstalled_containsIsPayPalInstalledTrue() {
         let mockURLOpener = MockURLOpener()
-        mockURLOpener.paypalInstalled = true
+        mockURLOpener.payPalInstalled = true
 
         let webView = WKWebView()
         let _ = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -393,12 +394,13 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
 
     func testUserScript_whenPayPalNotInstalled_containsIsPayPalInstalledFalse() {
         let mockURLOpener = MockURLOpener()
-        mockURLOpener.paypalInstalled = false
+        mockURLOpener.payPalInstalled = false
 
         let webView = WKWebView()
         let _ = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -412,6 +414,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let _ = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -434,6 +437,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let pub = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -459,6 +463,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let pub = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -485,6 +490,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let pub = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 
@@ -496,36 +502,6 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
 
         XCTAssertTrue(pub.returnedWithURL)
         XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.appLaunchFailed)
-    }
-
-    // MARK: - App Detection Analytics Tests
-
-    func testInit_whenPayPalInstalled_sendsPayPalInstalledAnalytics() {
-        let mockURLOpener = MockURLOpener()
-        mockURLOpener.paypalInstalled = true
-
-        POPPopupBridge.analyticsService = mockAnalyticsService
-        let _ = POPPopupBridge(
-            webView: WKWebView(),
-            webAuthenticationSession: mockWebAuthenticationSession,
-            application: mockURLOpener
-        )
-
-        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.paypalInstalled))
-    }
-
-    func testInit_whenPayPalNotInstalled_sendsPayPalNotInstalledAnalytics() {
-        let mockURLOpener = MockURLOpener()
-        mockURLOpener.paypalInstalled = false
-
-        POPPopupBridge.analyticsService = mockAnalyticsService
-        let _ = POPPopupBridge(
-            webView: WKWebView(),
-            webAuthenticationSession: mockWebAuthenticationSession,
-            application: mockURLOpener
-        )
-
-        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.paypalNotInstalled))
     }
 
     func testReceiveScriptMessage_whenLaunchApp_sendsAppLaunchStartedAnalytics() {
@@ -541,6 +517,7 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         let pub = POPPopupBridge(
             webView: webView,
             webAuthenticationSession: mockWebAuthenticationSession,
+            enablePopupBridgeAppSwitch: true,
             application: mockURLOpener
         )
 

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -527,6 +527,13 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
 
         pub.userContentController(WKUserContentController(), didReceive: stubMessage)
 
-        XCTAssertTrue(mockAnalyticsService.allEventNames.contains(PopupBridgeAnalytics.appLaunchStarted))
+        XCTAssertEqual(
+            mockAnalyticsService.sentEventNames,
+            [
+                PopupBridgeAnalytics.started,
+                PopupBridgeAnalytics.appLaunchStarted,
+                PopupBridgeAnalytics.appLaunchSucceeded
+            ]
+        )
     }
 }

--- a/UnitTests/PopupBridge_UnitTests.swift
+++ b/UnitTests/PopupBridge_UnitTests.swift
@@ -501,7 +501,9 @@ final class PopupBridge_UnitTests: XCTestCase, WKNavigationDelegate {
         pub.userContentController(WKUserContentController(), didReceive: stubMessage)
 
         XCTAssertTrue(pub.returnedWithURL)
-        XCTAssertEqual(mockAnalyticsService.lastEventName, PopupBridgeAnalytics.appLaunchFailed)
+        // appLaunchFailed is sent before the WebAuthenticationSession fallback fires succeeded,
+        // so check the full event sequence rather than just lastEventName.
+        XCTAssertTrue(mockAnalyticsService.sentEventNames.contains(PopupBridgeAnalytics.appLaunchFailed))
     }
 
     func testReceiveScriptMessage_whenLaunchApp_sendsAppLaunchStartedAnalytics() {


### PR DESCRIPTION
### Summary of changes

- Add PayPal app switch support to PopupBridge
- Introduces an optional `enablePopupBridgeAppSwitch` flag to `POPPopupBridge` that, when enabled, allows the SDK to launch the native PayPal app for checkout instead of opening a browser session. 
- When the app launch succeeds, a `NotificationCenter` observer handles the deep link return URL and injects the result back into the WebView. If the app launch fails, the flow falls back to the existing `WebAuthenticationSession` behavior. 
- Exposes `isPayPalInstalled`, `launchApp()`, and `getDeepLinkReturnUrlPrefix()` to JavaScript, and fires analytics events for app detection and launch outcomes.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jtanya17 
