### PR TITLE
fix: use PAT for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Use Xcode 16.4.0
         run: sudo xcode-select -switch /Applications/Xcode_16.4.0.app


### PR DESCRIPTION
### Summary of changes
This changes the release workflow to use a personal access token for the git commands at the end of the release workflow. This should resolve the issue where the version change push to main fails due to the ruleset requirements we have in place. The PAT is coming from a secure new github account/user that only the SDK team has access to. This user has been included in the bypass list for the ruleset and I've added the token to the repo secrets

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [ ] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
no AI was used

**Estimated AI Code Contribution**
- [ ] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [ ] Added a changelog entry
- [ ] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
- @saralvasquez 
